### PR TITLE
document `is()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,22 @@ is(req, ['application/json']) // 'application/json'
 is(req, ['html']) // false
 ```
 
-#### Each type can be:
+### type = is.is(mediaType, types)
+
+`mediaType` is the [media type](https://tools.ietf.org/html/rfc6838) string. `types` is an array of types.
+
+```js
+var mediaType = 'application/json'
+
+is.is(mediaType, ['json'])             // 'json'
+is.is(mediaType, ['html', 'json'])     // 'json'
+is.is(mediaType, ['application/*'])    // 'application/json'
+is.is(mediaType, ['application/json']) // 'application/json'
+
+is.is(mediaType, ['html']) // false
+```
+
+### Each type can be:
 
 - An extension name such as `json`. This name will be returned if matched.
 - A mime type such as `application/json`.


### PR DESCRIPTION
The user of the library may not want to pass in a request object, but instead the simple media type string. Since this method is already available (albeit awkward, since the variable used in the examples is `is`), it might as well be documented. In [my use case](%28https://github.com/afeld/jsonp/blob/8e6e35a703a31c0fdf0b09779e5420aeeb4c88a7/lib/jsonp.js#L12-L13%29), I am trying to check the `Content-Type` of the response in Express middleware. Thanks!
