### PR TITLE
Support http2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,9 @@ script:
   - "test   -z $(npm -ps ls eslint  ) || npm run-script lint"
 after_script:
   - "test -e ./coverage/lcov.info && npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"
+matrix:
+  include:
+    - node_js: "9.5"
+      env: HTTP2_TEST=1
+    - node_js: "8.9"
+      env: HTTP2_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - "test $TRAVIS_NODE_VERSION != '0.6' || npm rm --save-dev istanbul"
   - "test $TRAVIS_NODE_VERSION != '0.8' || npm rm --save-dev istanbul"
   - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) -ge 4 || npm rm --save-dev $(grep -E '\"eslint\\S*\"' package.json | cut -d'\"' -f2)"
+  - "test -z $(echo $HTTP2_TEST) || npm install --only=dev https://github.com/visionmedia/superagent.git"
 
   # Update Node.js modules
   - "test ! -d node_modules || npm prune"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
   - "test $TRAVIS_NODE_VERSION != '0.6' || npm rm --save-dev istanbul"
   - "test $TRAVIS_NODE_VERSION != '0.8' || npm rm --save-dev istanbul"
   - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) -ge 4 || npm rm --save-dev $(grep -E '\"eslint\\S*\"' package.json | cut -d'\"' -f2)"
-  - "test -z $(echo $HTTP2_TEST) || npm install https://github.com/visionmedia/superagent.git"
 
   # Update Node.js modules
   - "test ! -d node_modules || npm prune"
@@ -40,7 +39,5 @@ after_script:
   - "test -e ./coverage/lcov.info && npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"
 matrix:
   include:
-    - node_js: "9.5"
-      env: HTTP2_TEST=1
-    - node_js: "8.9"
+    - node_js: "10.11"
       env: HTTP2_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - "test $TRAVIS_NODE_VERSION != '0.6' || npm rm --save-dev istanbul"
   - "test $TRAVIS_NODE_VERSION != '0.8' || npm rm --save-dev istanbul"
   - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) -ge 4 || npm rm --save-dev $(grep -E '\"eslint\\S*\"' package.json | cut -d'\"' -f2)"
-  - "test -z $(echo $HTTP2_TEST) || npm install --only=dev https://github.com/visionmedia/superagent.git"
+  - "test -z $(echo $HTTP2_TEST) || npm install https://github.com/visionmedia/superagent.git"
 
   # Update Node.js modules
   - "test ! -d node_modules || npm prune"

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function typeis (value, types_) {
  *
  * A http/2 request with DataFrame can have no `content-length` header.
  * https://httpwg.org/specs/rfc7540.html
- * 
+ *
  * A http/2 request without DataFrame send HeaderFrame with end-stream-flag.
  * If nodejs gets end-stream-flag, then nodejs ends readable stream.
  * https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L301
@@ -97,7 +97,7 @@ function typeis (value, types_) {
  */
 
 function hasbody (req) {
-  return (ishttp2(req) && !req.stream._readableState.ended)||
+  return (ishttp2(req) && !req.stream._readableState.ended) ||
     req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
 }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function typeis (value, types_) {
  */
 
 function hasbody (req) {
-  return (ishttp2(req) && (req.stream.readable || !req.stream._readableState.sync)) ||
+  return (ishttp2(req) && !req.stream.endAfterHeaders) ||
     req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
 }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function typeis (value, types_) {
  */
 
 function hasbody (req) {
-  return (ishttp2(req) && !req.stream._readableState.ended) ||
+  return (ishttp2(req) && (req.stream.readable || req.stream._readableState.endEmitted)) ||
     req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
 }

--- a/index.js
+++ b/index.js
@@ -86,6 +86,10 @@ function typeis (value, types_) {
  *
  * A http/2 request with DataFrame can have no `content-length` header.
  * https://httpwg.org/specs/rfc7540.html
+ * 
+ * A http/2 request without DataFrame send HeaderFrame with end-stream-flag.
+ * If nodejs gets end-stream-flag, then nodejs ends readable stream.
+ * https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L301
  *
  * @param {Object} request
  * @return {Boolean}
@@ -93,7 +97,7 @@ function typeis (value, types_) {
  */
 
 function hasbody (req) {
-  return ishttp2(req) ||
+  return (ishttp2(req) && !req.stream._readableState.ended)||
     req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
 }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function typeis (value, types_) {
  */
 
 function hasbody (req) {
-  return (ishttp2(req) && (req.stream.readable || req.stream._readableState.endEmitted)) ||
+  return (ishttp2(req) && (req.stream.readable || !req.stream._readableState.sync)) ||
     req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
 }

--- a/index.js
+++ b/index.js
@@ -84,14 +84,30 @@ function typeis (value, types_) {
  * or `content-length` headers set.
  * http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
  *
+ * A http/2 request with DataFrame can have no `content-length` header.
+ * https://httpwg.org/specs/rfc7540.html
+ *
  * @param {Object} request
  * @return {Boolean}
  * @public
  */
 
 function hasbody (req) {
-  return req.headers['transfer-encoding'] !== undefined ||
+  return ishttp2(req) ||
+    req.headers['transfer-encoding'] !== undefined ||
     !isNaN(req.headers['content-length'])
+}
+
+/**
+ * Check if a request is a http2 request.
+ *
+ * @param {Object} request
+ * @return {Boolean}
+ * @public
+ */
+
+function ishttp2 (req) {
+  return req.httpVersionMajor === 2
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "lint": "eslint --plugin markdown --ext js,md .",
     "test": "mocha --reporter spec --check-leaks --bail test/",
+    "test-http2": "HTTP2_TEST=1 mocha --reporter spec --check-leaks --bail test/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",
     "istanbul": "0.4.5",
-    "mocha": "1.21.5"
+    "mocha": "1.21.5",
+    "superagent": "git+https://github.com/visionmedia/superagent.git"
   },
   "engines": {
     "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",
     "istanbul": "0.4.5",
-    "mocha": "1.21.5",
-    "superagent": "git+https://github.com/visionmedia/superagent.git"
+    "mocha": "1.21.5"
   },
   "engines": {
     "node": ">= 0.6"

--- a/test/test.js
+++ b/test/test.js
@@ -59,16 +59,14 @@ describe('typeis(req, type)', function () {
   })
 
   describe('when no content type is given', function () {
-    if (!process.env.HTTP2_TEST) {
-      it('should return false', function (done) {
-        createRequest('', function (req) {
-          assert.strictEqual(typeis(req), false)
-          assert.strictEqual(typeis(req, ['image/*']), false)
-          assert.strictEqual(typeis(req, ['text/*', 'image/*']), false)
-          done()
-        })
+    it('should return false', function (done) {
+      createRequest('', function (req) {
+        assert.strictEqual(typeis(req), false)
+        assert.strictEqual(typeis(req, ['image/*']), false)
+        assert.strictEqual(typeis(req, ['text/*', 'image/*']), false)
+        done()
       })
-    }
+    })
   })
 
   describe('give no types', function () {
@@ -261,8 +259,8 @@ function createRequest (type, callback) {
 
     server = server.listen(function () {
       request.post(`localhost:${server.address().port}/`)
-        .set('content-type', type || '')
-        .send('buffer')
+        .send('hello')
+        .set('content-type', type || undefined)
         .end()
     })
   } else {
@@ -284,7 +282,7 @@ function createBodylessRequest (type, callback) {
 
     server = server.listen(function () {
       request.get(`localhost:${server.address().port}/`)
-        .set('content-type', type || '')
+        .set('content-type', type || undefined)
         .end()
     })
   } else {

--- a/test/test.js
+++ b/test/test.js
@@ -3,13 +3,13 @@ var assert = require('assert')
 var typeis = require('..')
 var request
 var http2
-var readable
+var Readable
 
 if (process.env.HTTP2_TEST) {
   http2 = require('http2')
   request = require('superagent')
   request.http2 = true
-  readable = require('stream').Readable;
+  Readable = require('stream').Readable
 }
 
 describe('typeis(req, type)', function () {
@@ -252,12 +252,12 @@ describe('typeis.hasBody(req)', function () {
 
       it('should indicate body after end event occurred', function (done) {
         createRequest('', function (req) {
-          var data = '';
-          req.on('data', function(chunk) {
+          var data = ''
+          req.on('data', function (chunk) {
             data += chunk
           })
-          req.on('end', function(chunk) {
-            process.nextTick( function(){
+          req.on('end', function (chunk) {
+            process.nextTick(function () {
               assert.strictEqual(data, 'hello')
               assert.strictEqual(typeis.hasBody(req), true)
               done()
@@ -277,7 +277,7 @@ function createRequest (type, callback) {
     })
 
     server = server.listen(function () {
-      var s = new readable()
+      var s = new Readable()
       s.push('hello')
       s.push(null)
       var req = request.post('localhost:' + server.address().port + '/')

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,13 @@
 
 var assert = require('assert')
 var typeis = require('..')
-var request = require('superagent')
+var request
 var http2
 
 if (process.env.HTTP2_TEST) {
-  request.http2 = true
   http2 = require('http2')
+  request = require('superagent')
+  request.http2 = true
 }
 
 describe('typeis(req, type)', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -174,13 +174,30 @@ describe('typeis.hasBody(req)', function () {
       assert.strictEqual(typeis.hasBody(req), true)
     })
   })
+
+  describe('http2 request', function () {
+    it('should indicate body', function () {
+      var req = {headers: {}, httpVersionMajor: 2}
+      assert.strictEqual(typeis.hasBody(req), true)
+    })
+  })
 })
 
 function createRequest (type) {
-  return {
-    headers: {
-      'content-type': type || '',
-      'transfer-encoding': 'chunked'
+  if (process.env.HTTP2_TEST) {
+    console.log('http2')
+    return {
+      headers: {
+        'content-type': type || ''
+      },
+      httpVersionMajor: 2
+    }
+  } else {
+    return {
+      headers: {
+        'content-type': type || '',
+        'transfer-encoding': 'chunked'
+      }
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -176,8 +176,29 @@ describe('typeis.hasBody(req)', function () {
   })
 
   describe('http2 request', function () {
+    it('should not indicate body', function () {
+      var req = {
+        headers: {}, 
+        stream: {
+          _readableState: {
+            ended: true
+          }
+        },
+        httpVersionMajor: 2
+      }
+      assert.strictEqual(typeis.hasBody(req), false)
+    })
+
     it('should indicate body', function () {
-      var req = {headers: {}, httpVersionMajor: 2}
+      var req = {
+        headers: {}, 
+        stream: {
+          _readableState: {
+            ended: false
+          }
+        },
+        httpVersionMajor: 2
+      }
       assert.strictEqual(typeis.hasBody(req), true)
     })
   })
@@ -185,10 +206,14 @@ describe('typeis.hasBody(req)', function () {
 
 function createRequest (type) {
   if (process.env.HTTP2_TEST) {
-    console.log('http2')
     return {
       headers: {
         'content-type': type || ''
+      },
+      stream: {
+        _readableState: {
+          ended: false
+        }
       },
       httpVersionMajor: 2
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 
 var assert = require('assert')
 var typeis = require('..')
-var request
 var http2
 var Readable
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,151 +1,209 @@
 
 var assert = require('assert')
 var typeis = require('..')
+var request = require('superagent')
+var http2
+
+if (process.env.HTTP2_TEST) {
+  request.http2 = true
+  http2 = require('http2')
+}
 
 describe('typeis(req, type)', function () {
-  it('should ignore params', function () {
-    var req = createRequest('text/html; charset=utf-8')
-    assert.equal(typeis(req, ['text/*']), 'text/html')
+  it('should ignore params', function (done) {
+    createRequest('text/html; charset=utf-8', function (req) {
+      assert.equal(typeis(req, ['text/*']), 'text/html')
+      done()
+    })
   })
 
-  it('should ignore params LWS', function () {
-    var req = createRequest('text/html ; charset=utf-8')
-    assert.equal(typeis(req, ['text/*']), 'text/html')
+  it('should ignore params LWS', function (done) {
+    createRequest('text/html ; charset=utf-8', function (req) {
+      assert.equal(typeis(req, ['text/*']), 'text/html')
+      done()
+    })
   })
 
-  it('should ignore casing', function () {
-    var req = createRequest('text/HTML')
-    assert.equal(typeis(req, ['text/*']), 'text/html')
+  it('should ignore casing', function (done) {
+    createRequest('text/HTML', function (req) {
+      assert.equal(typeis(req, ['text/*']), 'text/html')
+      done()
+    })
   })
 
-  it('should fail invalid type', function () {
-    var req = createRequest('text/html**')
-    assert.strictEqual(typeis(req, ['text/*']), false)
+  it('should fail invalid type', function (done) {
+    createRequest('text/html**', function (req) {
+      assert.strictEqual(typeis(req, ['text/*']), false)
+      done()
+    })
   })
 
-  it('should not match invalid type', function () {
-    var req = createRequest('text/html')
-    assert.strictEqual(typeis(req, ['text/html/']), false)
-    assert.strictEqual(typeis(req, [undefined, null, true, function () {}]), false)
+  it('should not match invalid type', function (done) {
+    createRequest('text/html', function (req) {
+      assert.strictEqual(typeis(req, ['text/html/']), false)
+      assert.strictEqual(typeis(req, [undefined, null, true, function () {}]), false)
+      done()
+    })
   })
 
   describe('when no body is given', function () {
-    it('should return null', function () {
-      var req = {headers: {}}
-
-      assert.strictEqual(typeis(req), null)
-      assert.strictEqual(typeis(req, ['image/*']), null)
-      assert.strictEqual(typeis(req, 'image/*', 'text/*'), null)
+    it('should return null', function (done) {
+      createBodylessRequest('', function (req) {
+        assert.strictEqual(typeis(req), null)
+        assert.strictEqual(typeis(req, ['image/*']), null)
+        assert.strictEqual(typeis(req, 'image/*', 'text/*'), null)
+        done()
+      })
     })
   })
 
   describe('when no content type is given', function () {
-    it('should return false', function () {
-      var req = createRequest()
-      assert.strictEqual(typeis(req), false)
-      assert.strictEqual(typeis(req, ['image/*']), false)
-      assert.strictEqual(typeis(req, ['text/*', 'image/*']), false)
-    })
+    if (!process.env.HTTP2_TEST) {
+      it('should return false', function (done) {
+        createRequest('', function (req) {
+          assert.strictEqual(typeis(req), false)
+          assert.strictEqual(typeis(req, ['image/*']), false)
+          assert.strictEqual(typeis(req, ['text/*', 'image/*']), false)
+          done()
+        })
+      })
+    }
   })
 
   describe('give no types', function () {
-    it('should return the mime type', function () {
-      var req = createRequest('image/png')
-      assert.equal(typeis(req), 'image/png')
+    it('should return the mime type', function (done) {
+      createRequest('image/png', function (req) {
+        assert.equal(typeis(req), 'image/png')
+        done()
+      })
     })
   })
 
   describe('given one type', function () {
-    it('should return the type or false', function () {
-      var req = createRequest('image/png')
+    it('should return the type or false', function (done) {
+      createRequest('image/png', function (req) {
+        assert.equal(typeis(req, ['png']), 'png')
+        assert.equal(typeis(req, ['.png']), '.png')
+        assert.equal(typeis(req, ['image/png']), 'image/png')
+        assert.equal(typeis(req, ['image/*']), 'image/png')
+        assert.equal(typeis(req, ['*/png']), 'image/png')
 
-      assert.equal(typeis(req, ['png']), 'png')
-      assert.equal(typeis(req, ['.png']), '.png')
-      assert.equal(typeis(req, ['image/png']), 'image/png')
-      assert.equal(typeis(req, ['image/*']), 'image/png')
-      assert.equal(typeis(req, ['*/png']), 'image/png')
+        assert.strictEqual(typeis(req, ['jpeg']), false)
+        assert.strictEqual(typeis(req, ['.jpeg']), false)
+        assert.strictEqual(typeis(req, ['image/jpeg']), false)
+        assert.strictEqual(typeis(req, ['text/*']), false)
+        assert.strictEqual(typeis(req, ['*/jpeg']), false)
 
-      assert.strictEqual(typeis(req, ['jpeg']), false)
-      assert.strictEqual(typeis(req, ['.jpeg']), false)
-      assert.strictEqual(typeis(req, ['image/jpeg']), false)
-      assert.strictEqual(typeis(req, ['text/*']), false)
-      assert.strictEqual(typeis(req, ['*/jpeg']), false)
-
-      assert.strictEqual(typeis(req, ['bogus']), false)
-      assert.strictEqual(typeis(req, ['something/bogus*']), false)
+        assert.strictEqual(typeis(req, ['bogus']), false)
+        assert.strictEqual(typeis(req, ['something/bogus*']), false)
+        done()
+      })
     })
   })
 
   describe('given multiple types', function () {
-    it('should return the first match or false', function () {
-      var req = createRequest('image/png')
+    it('should return the first match or false', function (done) {
+      createRequest('image/png', function (req) {
+        assert.equal(typeis(req, ['png']), 'png')
+        assert.equal(typeis(req, '.png'), '.png')
+        assert.equal(typeis(req, ['text/*', 'image/*']), 'image/png')
+        assert.equal(typeis(req, ['image/*', 'text/*']), 'image/png')
+        assert.equal(typeis(req, ['image/*', 'image/png']), 'image/png')
+        assert.equal(typeis(req, 'image/png', 'image/*'), 'image/png')
 
-      assert.equal(typeis(req, ['png']), 'png')
-      assert.equal(typeis(req, '.png'), '.png')
-      assert.equal(typeis(req, ['text/*', 'image/*']), 'image/png')
-      assert.equal(typeis(req, ['image/*', 'text/*']), 'image/png')
-      assert.equal(typeis(req, ['image/*', 'image/png']), 'image/png')
-      assert.equal(typeis(req, 'image/png', 'image/*'), 'image/png')
-
-      assert.strictEqual(typeis(req, ['jpeg']), false)
-      assert.strictEqual(typeis(req, ['.jpeg']), false)
-      assert.strictEqual(typeis(req, ['text/*', 'application/*']), false)
-      assert.strictEqual(typeis(req, ['text/html', 'text/plain', 'application/json']), false)
+        assert.strictEqual(typeis(req, ['jpeg']), false)
+        assert.strictEqual(typeis(req, ['.jpeg']), false)
+        assert.strictEqual(typeis(req, ['text/*', 'application/*']), false)
+        assert.strictEqual(typeis(req, ['text/html', 'text/plain', 'application/json']), false)
+        done()
+      })
     })
   })
 
   describe('given +suffix', function () {
-    it('should match suffix types', function () {
-      var req = createRequest('application/vnd+json')
-
-      assert.equal(typeis(req, '+json'), 'application/vnd+json')
-      assert.equal(typeis(req, 'application/vnd+json'), 'application/vnd+json')
-      assert.equal(typeis(req, 'application/*+json'), 'application/vnd+json')
-      assert.equal(typeis(req, '*/vnd+json'), 'application/vnd+json')
-      assert.strictEqual(typeis(req, 'application/json'), false)
-      assert.strictEqual(typeis(req, 'text/*+json'), false)
+    it('should match suffix types', function (done) {
+      createRequest('application/vnd+json', function (req) {
+        assert.equal(typeis(req, '+json'), 'application/vnd+json')
+        assert.equal(typeis(req, 'application/vnd+json'), 'application/vnd+json')
+        assert.equal(typeis(req, 'application/*+json'), 'application/vnd+json')
+        assert.equal(typeis(req, '*/vnd+json'), 'application/vnd+json')
+        assert.strictEqual(typeis(req, 'application/json'), false)
+        assert.strictEqual(typeis(req, 'text/*+json'), false)
+        done()
+      })
     })
   })
 
   describe('given "*/*"', function () {
-    it('should match any content-type', function () {
-      assert.equal(typeis(createRequest('text/html'), '*/*'), 'text/html')
-      assert.equal(typeis(createRequest('text/xml'), '*/*'), 'text/xml')
-      assert.equal(typeis(createRequest('application/json'), '*/*'), 'application/json')
-      assert.equal(typeis(createRequest('application/vnd+json'), '*/*'), 'application/vnd+json')
+    describe('should match any content-type', function () {
+      it('text/html', function (done) {
+        createRequest('text/html', function (req) {
+          assert.equal(typeis(req, '*/*'), 'text/html')
+          done()
+        })
+      })
+
+      it('text/xml', function (done) {
+        createRequest('text/xml', function (req) {
+          assert.equal(typeis(req, '*/*'), 'text/xml')
+          done()
+        })
+      })
+
+      it('application/json', function (done) {
+        createRequest('application/json', function (req) {
+          assert.equal(typeis(req, '*/*'), 'application/json')
+          done()
+        })
+      })
+
+      it('application/vnd+json', function (done) {
+        createRequest('application/vnd+json', function (req) {
+          assert.equal(typeis(req, '*/*'), 'application/vnd+json')
+          done()
+        })
+      })
     })
 
-    it('should not match invalid content-type', function () {
-      assert.strictEqual(typeis(createRequest('bogus'), '*/*'), false)
+    it('should not match invalid content-type', function (done) {
+      createRequest('bogus', function (req) {
+        assert.strictEqual(typeis(req, '*/*'), false)
+        done()
+      })
     })
 
-    it('should not match body-less request', function () {
-      var req = {headers: {'content-type': 'text/html'}}
-      assert.strictEqual(typeis(req, '*/*'), null)
+    it('should not match body-less request', function (done) {
+      createBodylessRequest('text/html', function (req) {
+        assert.strictEqual(typeis(req, '*/*'), null)
+        done()
+      })
     })
   })
 
   describe('when Content-Type: application/x-www-form-urlencoded', function () {
-    it('should match "urlencoded"', function () {
-      var req = createRequest('application/x-www-form-urlencoded')
-
-      assert.equal(typeis(req, ['urlencoded']), 'urlencoded')
-      assert.equal(typeis(req, ['json', 'urlencoded']), 'urlencoded')
-      assert.equal(typeis(req, ['urlencoded', 'json']), 'urlencoded')
+    it('should match "urlencoded"', function (done) {
+      createRequest('application/x-www-form-urlencoded', function (req) {
+        assert.equal(typeis(req, ['urlencoded']), 'urlencoded')
+        assert.equal(typeis(req, ['json', 'urlencoded']), 'urlencoded')
+        assert.equal(typeis(req, ['urlencoded', 'json']), 'urlencoded')
+        done()
+      })
     })
   })
 
   describe('when Content-Type: multipart/form-data', function () {
-    it('should match "multipart/*"', function () {
-      var req = createRequest('multipart/form-data')
-
-      assert.equal(typeis(req, ['multipart/*']), 'multipart/form-data')
+    it('should match "multipart/*"', function (done) {
+      createRequest('multipart/form-data', function (req) {
+        assert.equal(typeis(req, ['multipart/*']), 'multipart/form-data')
+        done()
+      })
     })
 
-    it('should match "multipart"', function () {
-      var req = createRequest('multipart/form-data')
-
-      assert.equal(typeis(req, ['multipart']), 'multipart')
+    it('should match "multipart"', function (done) {
+      createRequest('multipart/form-data', function (req) {
+        assert.equal(typeis(req, ['multipart']), 'multipart')
+        done()
+      })
     })
   })
 })
@@ -175,54 +233,65 @@ describe('typeis.hasBody(req)', function () {
     })
   })
 
-  describe('http2 request', function () {
-    it('should not indicate body', function () {
-      var req = {
-        headers: {},
-        stream: {
-          _readableState: {
-            ended: true
-          }
-        },
-        httpVersionMajor: 2
-      }
-      assert.strictEqual(typeis.hasBody(req), false)
-    })
+  if (process.env.HTTP2_TEST) {
+    describe('http2 request', function () {
+      it('should not indicate body', function (done) {
+        createBodylessRequest('', function (req) {
+          assert.strictEqual(typeis.hasBody(req), false)
+          done()
+        })
+      })
 
-    it('should indicate body', function () {
-      var req = {
-        headers: {},
-        stream: {
-          _readableState: {
-            ended: false
-          }
-        },
-        httpVersionMajor: 2
-      }
-      assert.strictEqual(typeis.hasBody(req), true)
+      it('should indicate body', function (done) {
+        createRequest('', function (req) {
+          assert.strictEqual(typeis.hasBody(req), true)
+          done()
+        })
+      })
     })
-  })
+  }
 })
 
-function createRequest (type) {
+function createRequest (type, callback) {
   if (process.env.HTTP2_TEST) {
-    return {
-      headers: {
-        'content-type': type || ''
-      },
-      stream: {
-        _readableState: {
-          ended: false
-        }
-      },
-      httpVersionMajor: 2
-    }
+    var server = http2.createServer(function (req, res) {
+      callback(req)
+    })
+
+    server = server.listen(function () {
+      request.post(`localhost:${server.address().port}/`)
+        .set('content-type', type || '')
+        .send('buffer')
+        .end()
+    })
   } else {
-    return {
+    var req = {
       headers: {
         'content-type': type || '',
         'transfer-encoding': 'chunked'
       }
     }
+    callback(req)
+  }
+}
+
+function createBodylessRequest (type, callback) {
+  if (process.env.HTTP2_TEST) {
+    var server = http2.createServer(function (req, res) {
+      callback(req)
+    })
+
+    server = server.listen(function () {
+      request.get(`localhost:${server.address().port}/`)
+        .set('content-type', type || '')
+        .end()
+    })
+  } else {
+    var req = {
+      headers: {
+        'content-type': type || ''
+      }
+    }
+    callback(req)
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,36 @@ describe('typeis.hasBody(req)', function () {
         })
       })
 
+      it('should not indicate body after end event occurred', function (done) {
+        createBodylessRequest('', function (req) {
+          var data = ''
+          req.on('data', function (chunk) {
+            data += chunk
+          })
+          req.on('end', function (chunk) {
+            process.nextTick(function () {
+              assert.strictEqual(data, '')
+              assert.strictEqual(typeis.hasBody(req), false)
+              done()
+            })
+          })
+        })
+      })
+
+      it('should not indicate body while end event occurred', function (done) {
+        createBodylessRequest('', function (req) {
+          var data = ''
+          req.on('data', function (chunk) {
+            data += chunk
+          })
+          req.on('end', function (chunk) {
+            assert.strictEqual(data, '')
+            assert.strictEqual(typeis.hasBody(req), false)
+            done()
+          })
+        })
+      })
+
       it('should indicate body', function (done) {
         createRequest('', function (req) {
           assert.strictEqual(typeis.hasBody(req), true)
@@ -262,6 +292,29 @@ describe('typeis.hasBody(req)', function () {
               assert.strictEqual(typeis.hasBody(req), true)
               done()
             })
+          })
+        })
+      })
+
+      it('should indicate body while end event occurred', function (done) {
+        createRequest('', function (req) {
+          var data = ''
+          req.on('data', function (chunk) {
+            data += chunk
+          })
+          req.on('end', function (chunk) {
+            assert.strictEqual(data, 'hello')
+            assert.strictEqual(typeis.hasBody(req), true)
+            done()
+          })
+        })
+      })
+
+      it('should indicate body while data event', function (done) {
+        createRequest('', function (req) {
+          req.on('data', function (chunk) {
+            assert.strictEqual(typeis.hasBody(req), true)
+            done()
           })
         })
       })

--- a/test/test.js
+++ b/test/test.js
@@ -178,7 +178,7 @@ describe('typeis.hasBody(req)', function () {
   describe('http2 request', function () {
     it('should not indicate body', function () {
       var req = {
-        headers: {}, 
+        headers: {},
         stream: {
           _readableState: {
             ended: true
@@ -191,7 +191,7 @@ describe('typeis.hasBody(req)', function () {
 
     it('should indicate body', function () {
       var req = {
-        headers: {}, 
+        headers: {},
         stream: {
           _readableState: {
             ended: false

--- a/test/test.js
+++ b/test/test.js
@@ -281,7 +281,7 @@ function createBodylessRequest (type, callback) {
     })
 
     server = server.listen(function () {
-      request.get(`localhost:${server.address().port}/`)
+      request.get('localhost:' + server.address().port + '/')
         .set('content-type', type || undefined)
         .end()
     })

--- a/test/test.js
+++ b/test/test.js
@@ -255,6 +255,7 @@ function createRequest (type, callback) {
   if (process.env.HTTP2_TEST) {
     var server = http2.createServer(function (req, res) {
       callback(req)
+      server.close()
     })
 
     server = server.listen(function () {
@@ -278,6 +279,7 @@ function createBodylessRequest (type, callback) {
   if (process.env.HTTP2_TEST) {
     var server = http2.createServer(function (req, res) {
       callback(req)
+      server.close()
     })
 
     server = server.listen(function () {

--- a/test/test.js
+++ b/test/test.js
@@ -258,7 +258,7 @@ function createRequest (type, callback) {
     })
 
     server = server.listen(function () {
-      request.post(`localhost:${server.address().port}/`)
+      request.post('localhost:' + server.address().port + '/')
         .send('hello')
         .set('content-type', type || undefined)
         .end()


### PR DESCRIPTION
Support http2 to enable express tests with http2.
expressjs/express#3390.

`body-parser` cannot parse http2 body stream, because `hasBody` with `http2ServerRequest` always return false. A `http2ServerRequest` does not have any information about body had. I think `hasBody` with `http2ServerRequest` should return always true.