### PR TITLE
Avoid throwing unnecessary exception when content-type is empty.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@ unreleased
     - Add extensions to HEIC image types
     - Add new mime types
     - Add `text/mdx` with extension `.mdx`
+  * perf: prevent internal `throw` on invalid type
 
 1.6.16 / 2018-02-16
 ===================

--- a/index.js
+++ b/index.js
@@ -254,6 +254,10 @@ function normalizeType (value) {
  */
 
 function tryNormalizeType (value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
   try {
     return normalizeType(value)
   } catch (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -179,7 +179,7 @@ describe('typeis.hasBody(req)', function () {
 function createRequest (type) {
   return {
     headers: {
-      'content-type': type || '',
+      'content-type': type || undefined,
       'transfer-encoding': 'chunked'
     }
   }


### PR DESCRIPTION
Avoid throwing unnecessary exception when content-type is empty.