### PR TITLE
Travis-ci: added support for ppc64le & Removed unsupported versions for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ node_js:
   - "13.13"
   - "14.0"
 dist: trusty
+arch:
+    - amd64
+    - ppc64le
 env:
   global:
     # Suppress Node.js 0.6 compile warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,22 @@ node_js:
   - "12.16"
   - "13.13"
   - "14.0"
+jobs:
+    exclude:
+      - node-js: 0.6
+        arch: ppc64le
+      - node-js: 0.8
+        arch: ppc64le
+      - node-js: 0.10
+        arch: ppc64le
+      - node-js: 0.12
+        arch: ppc64le
+      - node-js: 1.8
+        arch: ppc64le
+      - node-js: 2.5
+        arch: ppc64le
+      - node-js: 3.3
+        arch: ppc64le
 dist: trusty
 arch:
     - amd64


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture and Removed unsupported versions for ppc64le support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra