### PR TITLE
Adds support for `HTAB` as well as `SP` as whitespace separators in `content-type` headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,14 +236,39 @@ function mimeMatch (expected, actual) {
  */
 
 function normalizeType (value) {
-  // parse the type
-  var type = typer.parse(value)
+  // Support passing `req-like` or `res-like` objects as argument,
+  // for backward compatibility.
+  if (typeof value === 'object') {
+    value = getcontenttype(value);
+  }
 
-  // remove the parameters
-  type.parameters = undefined
+  // Exclude parameters.
+  var index = value.indexOf(';')
+  if (index !== -1) {
+    value = value.slice(0, index)
+  }
+  // Content-type headers might use '\t' for whitespace,
+  // which is not supported by typer.parse, so we must trim.
+  value = value.trim()
+  var type = typer.parse(value)
 
   // reformat it
   return typer.format(type)
+}
+
+/**
+ * Copied from `media-typer` 0.3.0
+ */
+function getcontenttype(obj) {
+  if (typeof obj.getHeader === 'function') {
+    // res-like
+    return obj.getHeader('content-type')
+  }
+
+  if (typeof obj.headers === 'object') {
+    // req-like
+    return obj.headers && obj.headers['content-type']
+  }
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,11 @@ describe('typeis(req, types)', function () {
     assert.strictEqual(typeis(req, ['text/*']), 'text/html')
   })
 
+  it('should support tabs in LWS', function () {
+    var req = createRequest('text/html\t;\tcharset=utf-8')
+    assert.strictEqual(typeis(req, ['text/*']), 'text/html')
+  })
+
   it('should ignore casing', function () {
     var req = createRequest('text/HTML')
     assert.strictEqual(typeis(req, ['text/*']), 'text/html')
@@ -299,6 +304,13 @@ describe('typeis.is(mediaType, types)', function () {
 
       assert.strictEqual(typeis.is(req, ['png']), 'png')
       assert.strictEqual(typeis.is(req, ['jpeg']), false)
+    })
+
+    it('should ignore parameters in content-type header', function () {
+      var req = createRequest('application/json;\tencoding=utf-8')
+
+      assert.strictEqual(typeis.is(req, ['json']), 'json')
+      assert.strictEqual(typeis.is(req, ['text']), false)
     })
 
     it('should not check for body', function () {


### PR DESCRIPTION
Fixes issue #52. Notes:

- The fix applies to both `typeis` and `typeis.is`, instead of just `typeis`.

  This is because `typeis.is` can receive a req-like or res-like object (this behaviour is undocumented but [tested](https://github.com/jshttp/type-is/blob/7d19b7aab1ad671f59ba157ae0640cd4b1302ca5/test/test.js#L296-L311)). I wanted to avoid situations where `typeis(req, ...)` would work but `typeis.is(req, ...)`  would not.

- The fix breaks backward compatibility in that, previously, `typeis` would fail if the content-type parameters were not properly formatted. But, after this PR, it will just ignore them.

  i.e. previously, this would return `false`:

  `typeis.is('application/json; charset:utf-8', 'json') // Notice the ":" instead of "=" in charset`

  But after this PR, it will return `"json"`.

  This behaviour was documented (*...If the `Content-Type` header is invalid...*):

  https://github.com/jshttp/type-is/blob/7d19b7aab1ad671f59ba157ae0640cd4b1302ca5/README.md?plain=1#L35-L38

  But it was not tested in the case of invalid parameters. I am not sure of the best way forward:

  - Keep validating parameters, and make test cases for it,
  - Or update the documentation to clarify that parameters will not be validated.

- After this PR, `media-typer` dependency could be upgraded to 1.1.0.