### PR TITLE
Fix ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,8 @@ jobs:
       shell: bash
       run: |
         # eslint for linting
-        # - remove on Node.js < 8
-        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 8 ]]; then
+        # - remove on Node.js < 10
+        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 10 ]]; then
           node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
             grep -E '^eslint(-|$)' | \
             sort -r | \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           node-version: "17.9"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         name:
@@ -81,11 +81,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.1.2 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.1.2 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"
@@ -97,21 +97,23 @@ jobs:
 
         - name: Node.js 12.x
           node-version: "12.22"
+          npm-i: mocha@9.2.2
 
         - name: Node.js 13.x
           node-version: "13.14"
+          npm-i: mocha@9.2.2
 
         - name: Node.js 14.x
-          node-version: "14.19"
+          node-version: "14.21"
 
         - name: Node.js 15.x
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.14"
+          node-version: "16.20"
 
         - name: Node.js 17.x
-          node-version: "17.5"
+          node-version: "17.9"
 
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +122,8 @@ jobs:
       shell: bash -eo pipefail -l {0}
       run: |
         if [[ "${{ matrix.node-version }}" == 0.6* ]]; then
-          sudo apt-get install g++-4.8 gcc-4.8 libssl1.0-dev
+          sudo apt-get update
+          sudo apt-get install g++-4.8 gcc-4.8 libssl1.0-dev python2 python-is-python2
           export CC=/usr/bin/gcc-4.8
           export CXX=/usr/bin/g++-4.8
         fi
@@ -139,7 +142,12 @@ jobs:
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
 
     - name: Configure npm
-      run: npm config set shrinkwrap false
+      run: |
+        if [[ "$(npm config get package-lock)" == "true" ]]; then
+          npm config set package-lock false
+        else
+          npm config set shrinkwrap false
+        fi
 
     - name: Remove npm module(s) ${{ matrix.npm-rm }}
       run: npm rm --silent --save-dev ${{ matrix.npm-rm }}
@@ -153,8 +161,8 @@ jobs:
       shell: bash
       run: |
         # eslint for linting
-        # - remove on Node.js < 10
-        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 10 ]]; then
+        # - remove on Node.js < 8
+        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 8 ]]; then
           node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
             grep -E '^eslint(-|$)' | \
             sort -r | \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         - Node.js 15.x
         - Node.js 16.x
         - Node.js 17.x
+        - Node.js 18.x
+        - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
+        - Node.js 22.x
 
         include:
 
@@ -109,6 +114,21 @@ jobs:
 
         - name: Node.js 17.x
           node-version: "17.9"
+
+        - name: Node.js 18.x
+          node-version: "18.20"
+
+        - name: Node.js 19.x
+          node-version: "19.9"
+
+        - name: Node.js 20.x
+          node-version: "20.13"
+
+        - name: Node.js 21.x
+          node-version: "21.7"
+
+        - name: Node.js 22.x
+          node-version: "22.1"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.6
         - Node.js 0.8
         - Node.js 0.10
         - Node.js 0.12
@@ -33,10 +32,6 @@ jobs:
         - Node.js 17.x
 
         include:
-        - name: Node.js 0.6
-          node-version: "0.6"
-          npm-i: mocha@1.21.5
-          npm-rm: nyc
 
         - name: Node.js 0.8
           node-version: "0.8"
@@ -121,12 +116,6 @@ jobs:
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
       run: |
-        if [[ "${{ matrix.node-version }}" == 0.6* ]]; then
-          sudo apt-get update
-          sudo apt-get install g++-4.8 gcc-4.8 libssl1.0-dev python2 python-is-python2
-          export CC=/usr/bin/gcc-4.8
-          export CXX=/usr/bin/g++-4.8
-        fi
         nvm install --default ${{ matrix.node-version }}
         if [[ "${{ matrix.node-version }}" == 0.* && "$(cut -d. -f2 <<< "${{ matrix.node-version }}")" -lt 10 ]]; then
           nvm install --alias=npm 0.10


### PR DESCRIPTION
This PR fixes the CI pipeline

**Important**
This is a BREAKING CHANGE. This PR drops Node.js 0.6 on the CI pipeline. Please check https://github.com/expressjs/discussions/issues/236 which explains why we are doing so.

**Changelog**

* a01286cc1d3cff84ec8be40bd1270011418902cc fix nyc for Node.js 8 & 9 on ci pipeline  by @carpasse 
* b6619766fd087f7e24a375caf2d6c6000d4ee160 drop Node.js 0.6 CI pipeline by @carpasse 
* 42cd9212d84a88ed8ca320eec7b0fbdfc8f6a8da use actions/checkout@v4 on CI pipeline by @carpasse 
* 2fe581e3ee5957a1b305524b32a86962d17e2015 add missing versions of Node.js to CI pipeline by @carpasse 
* c23e6c6a7b08c280ec1a979214c602f0e0ed4e0a remove linting for Node.js 0.8 & 0.9 on CI pipeline. eslint won't run by @carpasse 


