### PR TITLE
Upgrade `content-type`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,11 +42,16 @@ module.exports.match = mimeMatch
  */
 
 function typeis (value, types_) {
+  // Backward compatibility. TODO: Remove.
+  if (value && typeof value === 'object') {
+    value = value.headers['content-type']
+  }
+
   var i
   var types = types_
 
   // remove parameters and normalize
-  var val = tryNormalizeType(value)
+  var val = normalizeType(value)
 
   // no type or invalid
   if (!val) {
@@ -228,23 +233,8 @@ function mimeMatch (expected, actual) {
  * @private
  */
 function normalizeType (value) {
-  // Parse the type
-  var type = contentType.parse(value).type
+  if (!value) return null
+  var type = contentType.parse(value, { parameters: false }).type
 
   return typer.test(type) ? type : null
-}
-
-/**
- * Try to normalize a type and remove parameters.
- *
- * @param {string} value
- * @return {(string|null)}
- * @private
- */
-function tryNormalizeType (value) {
-  try {
-    return value ? normalizeType(value) : null
-  } catch (err) {
-    return null
-  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://opencollective.com/express"
   },
   "dependencies": {
-    "content-type": "^1.0.5",
+    "content-type": "^2.0.0",
     "media-typer": "^1.1.0",
     "mime-types": "^3.0.0"
   },
@@ -29,7 +29,7 @@
     "nyc": "15.1.0"
   },
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 18"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Initially started refactoring but `package.json` is just wrong, should have been `>= 18`. Kept the broken `is(req)` supported behavior with a plan to drop that and the other API awkwardness ASAP.

Bumping here to allow `body-parser` and `express` to use `content-type@2` with deduplication.