### PR TITLE
Match text/xml with xml shortcut

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,8 @@ function normalize (type) {
       return 'application/x-www-form-urlencoded'
     case 'multipart':
       return 'multipart/*'
+    case 'xml':
+      return '*/xml'
   }
 
   if (type[0] === '+') {

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,13 @@ describe('typeis(req, types)', function () {
       assert.strictEqual(typeis(req, ['multipart']), 'multipart')
     })
   })
+
+  describe('when Content-Type is XML', function () {
+    it('should match "xml"', function () {
+      assert.strictEqual(typeis(createRequest('application/xml'), ['xml']), 'xml')
+      assert.strictEqual(typeis(createRequest('text/xml'), ['xml']), 'xml')
+    })
+  })
 })
 
 describe('typeis.hasBody(req)', function () {
@@ -293,6 +300,13 @@ describe('typeis.is(mediaType, types)', function () {
     })
   })
 
+  describe('when media type is XML', function () {
+    it('should match "xml"', function () {
+      assert.strictEqual(typeis.is('application/xml', ['xml']), 'xml')
+      assert.strictEqual(typeis.is('text/xml', ['xml']), 'xml')
+    })
+  })
+
   describe('when give request object', function () {
     it('should use the content-type header', function () {
       var req = createRequest('image/png')
@@ -385,6 +399,10 @@ describe('typeis.normalize(type)', function () {
 
   it('should expand special "multipart"', function () {
     assert.strictEqual(typeis.normalize('multipart'), 'multipart/*')
+  })
+
+  it('should expand special "xml"', function () {
+    assert.strictEqual(typeis.normalize('xml'), '*/xml')
   })
 })
 


### PR DESCRIPTION
Fixes #24.

This adds an explicit `xml` shortcut that normalizes to `*/xml`, so callers using `typeis(req, ["xml"])` or `typeis.is(value, ["xml"])` match both `application/xml` and `text/xml`.

Verification:
- `npm test`
- `npm run lint`
- `git diff --check HEAD~1..HEAD`
