### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,9 @@
     "content",
     "type",
     "checking"
-  ]
+  ],
+  "homepage": "https://github.com/jshttp/type-is",
+  "bugs": {
+    "url": "https://github.com/jshttp/type-is/issues"
+  }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.