### PR TITLE
fix: make xml shortcut match text/xml and application/xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ Normalize a `type` string. This works by performing the following:
 - Else the string is assumed to be a file extension and the mapped media type is
   returned, or `false` is there is no mapping.
 
-This includes two special mappings:
+This includes three special mappings:
 
 - `'multipart'` -> `'multipart/*'`
 - `'urlencoded'` -> `'application/x-www-form-urlencoded'`
+- `'xml'` -> `'*/xml'` (matches `application/xml`, `text/xml`, etc.)
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports.match = mimeMatch
 /**
  * Compare a `value` content-type with `types`.
  * Each `type` can be an extension like `html`,
- * a special shortcut like `multipart` or `urlencoded`,
+ * a special shortcut like `multipart`, `urlencoded`, or `xml`,
  * or a mime type.
  *
  * If no types match, `false` is returned.
@@ -168,6 +168,9 @@ function normalize (type) {
       return 'application/x-www-form-urlencoded'
     case 'multipart':
       return 'multipart/*'
+    case 'xml':
+      // Match both application/xml and text/xml (and any */xml)
+      return '*/xml'
   }
 
   if (type[0] === '+') {

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,23 @@ describe('typeis(req, types)', function () {
       assert.strictEqual(typeis(req, ['multipart']), 'multipart')
     })
   })
+
+  describe('when Content-Type: text/xml', function () {
+    it('should match "xml"', function () {
+      var req = createRequest('text/xml')
+
+      assert.strictEqual(typeis(req, ['xml']), 'xml')
+      assert.strictEqual(typeis(req, ['json', 'xml']), 'xml')
+    })
+  })
+
+  describe('when Content-Type: application/xml', function () {
+    it('should match "xml"', function () {
+      var req = createRequest('application/xml')
+
+      assert.strictEqual(typeis(req, ['xml']), 'xml')
+    })
+  })
 })
 
 describe('typeis.hasBody(req)', function () {
@@ -293,6 +310,19 @@ describe('typeis.is(mediaType, types)', function () {
     })
   })
 
+  describe('when media type is text/xml', function () {
+    it('should match "xml"', function () {
+      assert.strictEqual(typeis.is('text/xml', ['xml']), 'xml')
+      assert.strictEqual(typeis.is('text/xml', ['json', 'xml']), 'xml')
+    })
+  })
+
+  describe('when media type is application/xml', function () {
+    it('should match "xml"', function () {
+      assert.strictEqual(typeis.is('application/xml', ['xml']), 'xml')
+    })
+  })
+
   describe('when give request object', function () {
     it('should use the content-type header', function () {
       var req = createRequest('image/png')
@@ -385,6 +415,10 @@ describe('typeis.normalize(type)', function () {
 
   it('should expand special "multipart"', function () {
     assert.strictEqual(typeis.normalize('multipart'), 'multipart/*')
+  })
+
+  it('should expand special "xml"', function () {
+    assert.strictEqual(typeis.normalize('xml'), '*/xml')
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes #24: the `xml` shortcut only matched `application/xml` (via `mime.lookup`), so `text/xml` failed.
- Expand `xml` to `*/xml` like the existing `multipart` / `urlencoded` special shortcuts.
- Document the mapping and add tests for both media types.

## Test plan
- [x] `npm test` (57 passing on Node 20)
