### PR TITLE
Refactor to faster API shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,49 +20,51 @@ $ npm install type-is
 import { createServer } from "http";
 import * as typeis from "type-is";
 
+const isText = typeis.request(["text/*"]);
+
 http.createServer(function (req, res) {
-  var istext = typeis.request(req, ["text/*"]);
-  res.end("you " + (istext ? "sent" : "did not send") + " me text");
+  res.end("you " + (isText(req) ? "sent" : "did not send") + " me text");
 });
 ```
 
-### request(req, types)
+### typeis.is(types)
 
-Checks if the `request` is one of the `types`. If the request has no body,
-even if there is a `Content-Type` header, then `null` is returned. If the
-`Content-Type` header is invalid or does not matches any of the `types`, then
-`false` is returned. Otherwise, a string of the type that matched is returned.
-
-The `request` argument is expected to be a Node.js HTTP request. The `types`
-argument is an array of type strings.
+Compiles an array of type strings into a reusable matcher. The returned function accepts a `content-type` header and returns the first configured type that matches, or `undefined` when none match.
 
 Each type in the `types` array can be one of the following:
 
-- A file extension name such as `json`. This name will be returned if matched.
 - A mime type such as `application/json`.
 - A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.
-  The full mime type will be returned if matched.
-- A suffix such as `+json`. This can be combined with a wildcard such as
-  `*/vnd+json` or `application/*+json`. The full mime type will be returned
-  if matched.
+- A suffix such as `+json`. This can be combined with a wildcard such as `*/vnd+json` or `application/*+json`.
+- A configured shorthand such as `multipart` or `urlencoded`.
+- Any of the above with parameters that must also match, such as `application/json; charset=utf-8`.
 
-Some examples to illustrate the inputs and returned value:
+```js
+var isJson = typeis.is(["application/json", "application/*+json"]);
+
+isJson("application/json"); // => 'application/json'
+isJson("application/vnd.api+json"); // => 'application/*+json'
+isJson("text/html"); // => undefined
+```
+
+### typeis.request(types)
+
+Checks if the `request` is one of the `types`. If the request has no body, even if there is a `Content-Type` header, then `undefined` is returned. Otherwise it uses `is` to check the `content-type` header.
 
 ```js
 // req.headers.content-type = 'application/json'
 
-request(req, ["json"]); // => 'json'
-request(req, ["html", "json"]); // => 'json'
-request(req, ["application/*"]); // => 'application/json'
-request(req, ["application/json"]); // => 'application/json'
+request(["json"])(req); // => 'json'
+request(["html", "json"])(req); // => 'json'
+request(["application/*"])(req); // => 'application/*'
+request(["application/json"])(req); // => 'application/json'
 
-request(req, ["html"]); // => false
+request(["html"])(req); // => undefined
 ```
 
 ### typeis.hasBody(request)
 
-Returns a Boolean if the given `request` has a body, regardless of the
-`Content-Type` header.
+Returns true if the given `request` has a body based on the HTTP headers provided.
 
 Having a body has no relation to how large the body is (it may be 0 bytes).
 This is similar to how file existence works. If a body does exist, then this
@@ -78,87 +80,51 @@ if (typeis.hasBody(req)) {
 }
 ```
 
-### typeis.is(mediaType, types)
+### typeis.match(expected)
 
-Checks if the `mediaType` is one of the `types`. If the `mediaType` is invalid
-or does not matches any of the `types`, then `false` is returned. Otherwise, a
-string of the type that matched is returned.
-
-The `mediaType` argument is expected to be a
-[media type](https://tools.ietf.org/html/rfc6838) string. The `types` argument
-is an array of type strings.
-
-Each type in the `types` array can be one of the following:
-
-- A file extension name such as `json`. This name will be returned if matched.
-- A mime type such as `application/json`.
-- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.
-  The full mime type will be returned if matched.
-- A suffix such as `+json`. This can be combined with a wildcard such as
-  `*/vnd+json` or `application/*+json`. The full mime type will be returned
-  if matched.
-
-Some examples to illustrate the inputs and returned value:
+Compile the type string `expected` into a function that matches a MIME type.
 
 ```js
-var mediaType = "application/json";
-
-typeis.is(mediaType, ["json"]); // => 'json'
-typeis.is(mediaType, ["html", "json"]); // => 'json'
-typeis.is(mediaType, ["application/*"]); // => 'application/json'
-typeis.is(mediaType, ["application/json"]); // => 'application/json'
-
-typeis.is(mediaType, ["html"]); // => false
-```
-
-### typeis.match(expected, actual)
-
-Match the type string `expected` with `actual`, taking in to account wildcards.
-A wildcard can only be in the type of the subtype part of a media type and only
-in the `expected` value (as `actual` should be the real media type to match). A
-suffix can still be included even with a wildcard subtype. If an input is
-malformed, `false` will be returned.
-
-```js
-typeis.match("text/html", "text/html"); // => true
-typeis.match("*/html", "text/html"); // => true
-typeis.match("text/*", "text/html"); // => true
-typeis.match("*/*", "text/html"); // => true
-typeis.match("*/*+json", "application/x-custom+json"); // => true
+typeis.match("text/html")("text/html"); // => true
+typeis.match("*/html")("text/html"); // => true
+typeis.match("text/*")("text/html"); // => true
+typeis.match("*/*")("text/html"); // => true
+typeis.match("*/*+json")("application/x-custom+json"); // => true
 ```
 
 ### typeis.normalize(type)
 
 Normalize a `type` string. This works by performing the following:
 
-- If the `type` is not a string, `false` is returned.
-- If the string starts with `+` (so it is a `+suffix` shorthand like `+json`),
-  then it is expanded to contain the complete wildcard notation of `*/*+suffix`.
 - If the string contains a `/`, then it is returned as the type.
-- Else the string is assumed to be a file extension and the mapped media type is
-  returned, or `false` is there is no mapping.
+- If the string starts with `+` (so it is a `+suffix` shorthand like `+json`), then it is expanded to contain the complete wildcard notation of `*/*+suffix`.
+- Else the string is assumed to be a file extension and the mapped media type is returned, or the original input if there is no mapping.
 
-This includes two special mappings:
+The default extensions is kept minimal:
 
+- `'json'` -> `'application/json'`
 - `'multipart'` -> `'multipart/*'`
 - `'urlencoded'` -> `'application/x-www-form-urlencoded'`
+
+You can pass an object of `{ extensions: string | string[] }` to provide additional mappings.
 
 ## Examples
 
 ### Example body parser
 
 ```js
-var express = require("express");
-var typeis = require("type-is");
+const express = require("express");
+const typeis = require("type-is");
 
-var app = express();
+const app = express();
+const typeIs = typeis.request(["urlencoded", "json", "multipart"]);
 
 app.use(function bodyParser(req, res, next) {
   if (!typeis.hasBody(req)) {
     return next();
   }
 
-  switch (typeis.request(req, ["urlencoded", "json", "multipart"])) {
+  switch (typeIs(req)) {
     case "urlencoded":
       // parse urlencoded body
       throw new Error("implement urlencoded body parsing");

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The default extensions is kept minimal:
 - `'multipart'` -> `'multipart/*'`
 - `'urlencoded'` -> `'application/x-www-form-urlencoded'`
 
-You can pass an object of `{ extensions: string | string[] }` to provide additional mappings.
+You can pass an options object of `{ lookup: (value: string) => string | string[] | undefined }` to provide additional mappings, e.g. [`mime.lookup`](https://github.com/jshttp/mime-types#mimelookuppath).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ $ npm install type-is
 
 ```js
 import { createServer } from "http";
-import * as typeis from "type-is";
+import { TypeIs } from "type-is";
 
-const isText = typeis.request(["text/*"]);
+const isText = new TypeIs(["text/*"]);
 
 http.createServer(function (req, res) {
-  res.end("you " + (isText(req) ? "sent" : "did not send") + " me text");
+  res.end(
+    "you " + (isText.request(req) ? "sent" : "did not send") + " me text",
+  );
 });
 ```
 
-### typeis.is(types)
+### new TypeIs(types[, options])
 
-Compiles an array of type strings into a reusable matcher. The returned function accepts a `content-type` header and returns the first configured type that matches, or `undefined` when none match.
+Creates a reusable content type matcher. The optional `options` object accepts a `lookup` function for resolving shorthand types.
 
 Each type in the `types` array can be one of the following:
 
@@ -39,30 +41,34 @@ Each type in the `types` array can be one of the following:
 - A configured shorthand such as `multipart` or `urlencoded`.
 - Any of the above with parameters that must also match, such as `application/json; charset=utf-8`.
 
-```js
-var isJson = typeis.is(["application/json", "application/*+json"]);
+### typeIs.is(value)
 
-isJson("application/json"); // => 'application/json'
-isJson("application/vnd.api+json"); // => 'application/*+json'
-isJson("text/html"); // => undefined
+Checks a `content-type` value and returns the first configured type that matches, or `undefined` when none match.
+
+```js
+const isJson = new TypeIs(["application/json", "application/*+json"]);
+
+isJson.is("application/json"); // => 'application/json'
+isJson.is("application/vnd.api+json"); // => 'application/*+json'
+isJson.is("text/html"); // => undefined
 ```
 
-### typeis.request(types)
+### typeIs.request(request)
 
-Checks if the `request` is one of the `types`. If the request has no body, even if there is a `Content-Type` header, then `undefined` is returned. Otherwise it uses `is` to check the `content-type` header.
+Checks a request against the configured types. If the request has no body, even if there is a `Content-Type` header, then `undefined` is returned. Otherwise it uses `is` to check the `content-type` header.
 
 ```js
 // req.headers.content-type = 'application/json'
 
-request(["json"])(req); // => 'json'
-request(["html", "json"])(req); // => 'json'
-request(["application/*"])(req); // => 'application/*'
-request(["application/json"])(req); // => 'application/json'
+new TypeIs(["json"]).request(req); // => 'application/json'
+new TypeIs(["html", "json"]).request(req); // => 'application/json'
+new TypeIs(["application/*"]).request(req); // => 'application/*'
+new TypeIs(["application/json"]).request(req); // => 'application/json'
 
-request(["html"])(req); // => undefined
+new TypeIs(["html"]).request(req); // => undefined
 ```
 
-### typeis.hasBody(request)
+### hasBody(request)
 
 Returns true if the given `request` has a body based on the HTTP headers provided.
 
@@ -80,7 +86,7 @@ if (typeis.hasBody(req)) {
 }
 ```
 
-### typeis.match(expected)
+### match(expected)
 
 Compile the type string `expected` into a function that matches a MIME type.
 
@@ -92,7 +98,7 @@ typeis.match("*/*")("text/html"); // => true
 typeis.match("*/*+json")("application/x-custom+json"); // => true
 ```
 
-### typeis.normalize(type)
+### normalize(type)
 
 Normalize a `type` string. This works by performing the following:
 
@@ -114,24 +120,24 @@ You can pass an options object of `{ lookup: (value: string) => string | string[
 
 ```js
 const express = require("express");
-const typeis = require("type-is");
+const { TypeIs, hasBody } = require("type-is");
 
 const app = express();
-const typeIs = typeis.request(["urlencoded", "json", "multipart"]);
+const typeIs = new TypeIs(["urlencoded", "json", "multipart"]);
 
 app.use(function bodyParser(req, res, next) {
-  if (!typeis.hasBody(req)) {
+  if (!hasBody(req)) {
     return next();
   }
 
-  switch (typeIs(req)) {
-    case "urlencoded":
+  switch (typeIs.request(req)) {
+    case "application/x-www-form-urlencoded":
       // parse urlencoded body
       throw new Error("implement urlencoded body parsing");
-    case "json":
+    case "application/json":
       // parse json body
       throw new Error("implement json body parsing");
-    case "multipart":
+    case "multipart/*":
       // parse multipart body
       throw new Error("implement multipart body parsing");
     default:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist/"
   ],
   "scripts": {
+    "bench": "vitest bench",
     "build": "ts-scripts build",
     "format": "ts-scripts format",
     "prepare": "ts-scripts install && npm run build",

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from "vitest";
-import { hasBody, is, match, request, normalize } from "./index.js";
+import { TypeIs, hasBody, match, normalize } from "./index.js";
 
 describe("request", () => {
   const req = {
@@ -10,11 +10,11 @@ describe("request", () => {
   };
 
   bench("exact match", () => {
-    request(["application/json"])(req);
+    new TypeIs(["application/json"]).request(req);
   });
 
   bench("wildcard match", () => {
-    request(["text/*", "application/*"])(req);
+    new TypeIs(["text/*", "application/*"]).request(req);
   });
 });
 
@@ -37,34 +37,34 @@ describe("hasBody", () => {
 });
 
 describe("is", () => {
-  const exact = is(["application/json"]);
-  const wildcard = is(["text/*", "application/*"]);
-  const suffix = is(["application/*+json"]);
+  const exact = new TypeIs(["application/json"]);
+  const wildcard = new TypeIs(["text/*", "application/*"]);
+  const suffix = new TypeIs(["application/*+json"]);
 
   bench("exact match", () => {
-    exact("application/json");
+    exact.is("application/json");
   });
 
   bench("wildcard match", () => {
-    wildcard("application/json");
+    wildcard.is("application/json");
   });
 
   bench("suffix match", () => {
-    suffix("application/vnd.api+json");
+    suffix.is("application/vnd.api+json");
   });
 });
 
 describe("is one shot", () => {
   bench("exact match", () => {
-    is(["application/json"])("application/json");
+    new TypeIs(["application/json"]).is("application/json");
   });
 
   bench("wildcard match", () => {
-    is(["text/*", "application/*"])("application/json");
+    new TypeIs(["text/*", "application/*"]).is("application/json");
   });
 
   bench("suffix match", () => {
-    is(["application/*+json"])("application/vnd.api+json");
+    new TypeIs(["application/*+json"]).is("application/vnd.api+json");
   });
 });
 

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -54,6 +54,20 @@ describe("is", () => {
   });
 });
 
+describe("is one shot", () => {
+  bench("exact match", () => {
+    is(["application/json"])("application/json");
+  });
+
+  bench("wildcard match", () => {
+    is(["text/*", "application/*"])("application/json");
+  });
+
+  bench("suffix match", () => {
+    is(["application/*+json"])("application/vnd.api+json");
+  });
+});
+
 describe("normalize", () => {
   bench("mime type", () => {
     normalize("application/json");

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,0 +1,114 @@
+import { bench, describe } from "vitest";
+import { hasBody, is, match, request, normalize } from "./index.js";
+
+describe("request", () => {
+  const req = {
+    headers: {
+      "content-length": "17",
+      "content-type": "application/json; charset=utf-8",
+    },
+  };
+
+  bench("exact match", () => {
+    request(["application/json"])(req);
+  });
+
+  bench("wildcard match", () => {
+    request(["text/*", "application/*"])(req);
+  });
+});
+
+describe("hasBody", () => {
+  const contentLength = { headers: { "content-length": "17" } };
+  const transferEncoding = { headers: { "transfer-encoding": "chunked" } };
+  const noBody = { headers: {} };
+
+  bench("content-length", () => {
+    hasBody(contentLength);
+  });
+
+  bench("transfer-encoding", () => {
+    hasBody(transferEncoding);
+  });
+
+  bench("without body headers", () => {
+    hasBody(noBody);
+  });
+});
+
+describe("is", () => {
+  const exact = is(["application/json"]);
+  const wildcard = is(["text/*", "application/*"]);
+  const suffix = is(["application/*+json"]);
+
+  bench("exact match", () => {
+    exact("application/json");
+  });
+
+  bench("wildcard match", () => {
+    wildcard("application/json");
+  });
+
+  bench("suffix match", () => {
+    suffix("application/vnd.api+json");
+  });
+});
+
+describe("normalize", () => {
+  bench("mime type", () => {
+    normalize("application/json");
+  });
+
+  bench("extension", () => {
+    normalize("json");
+  });
+
+  bench("shortcut", () => {
+    normalize("urlencoded");
+  });
+
+  bench("suffix", () => {
+    normalize("+json");
+  });
+});
+
+describe("match", () => {
+  const exact = match("application/json");
+  const typeWildcard = match("*/json");
+  const subtypeWildcard = match("application/*");
+  const suffixWildcard = match("application/*+json");
+
+  bench("exact", () => {
+    exact("application/json");
+  });
+
+  bench("type wildcard", () => {
+    typeWildcard("application/json");
+  });
+
+  bench("subtype wildcard", () => {
+    subtypeWildcard("application/json");
+  });
+
+  bench("suffix wildcard", () => {
+    suffixWildcard("application/vnd.api+json");
+  });
+});
+
+describe("match one shot", () => {
+  bench("exact", () => {
+    match("application/json")("application/json");
+  });
+
+  bench("type wildcard", () => {
+    match("*/json")("application/json");
+  });
+
+  bench("subtype wildcard", () => {
+    match("application/*")("application/json");
+  });
+
+  bench("suffix wildcard", () => {
+    match("application/*+json")("application/vnd.api+json");
+  });
+});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,95 +1,87 @@
 import { describe, it, assert } from "vitest";
 import { is, request, hasBody, normalize, match } from "./index.js";
 
-describe("request(req, types)", () => {
+describe("request(types)", () => {
   it("should ignore params", () => {
     const req = createRequest("text/html; charset=utf-8");
-    assert.strictEqual(request(req, ["text/*"]), "text/html");
+    assert.strictEqual(request(["text/*"])(req), "text/*");
   });
 
   it("should ignore params LWS", () => {
     const req = createRequest("text/html ; charset=utf-8");
-    assert.strictEqual(request(req, ["text/*"]), "text/html");
+    assert.strictEqual(request(["text/*"])(req), "text/*");
   });
 
   it("should ignore casing", () => {
     const req = createRequest("text/HTML");
-    assert.strictEqual(request(req, ["text/*"]), "text/html");
+    assert.strictEqual(request(["text/*"])(req), "text/*");
   });
 
-  it("should fail invalid type", () => {
+  it("should parse the content-type header", () => {
     const req = createRequest("text/html**");
-    assert.strictEqual(request(req, ["text/*"]), false);
+    assert.strictEqual(request(["text/*"])(req), "text/*");
   });
 
-  it("should not match invalid type", () => {
-    const req = createRequest("text/html");
-    assert.strictEqual(request(req, ["text/html/"]), false);
+  it("should reject invalid expected types", () => {
+    assert.throws(() => request(["text/html/"]), /Invalid mime type/);
   });
 
   describe("when no body is given", () => {
-    it("should return null", () => {
+    it("should return undefined", () => {
       const req = { headers: {} };
 
-      assert.strictEqual(request(req), false);
-      assert.strictEqual(request(req, ["image/*"]), false);
+      assert.strictEqual(request([])(req), undefined);
+      assert.strictEqual(request(["image/*"])(req), undefined);
     });
   });
 
   describe("when no content type is given", () => {
-    it("should return false", () => {
+    it("should return undefined", () => {
       const req = createRequest();
-      assert.strictEqual(request(req), false);
-      assert.strictEqual(request(req, ["image/*"]), false);
-      assert.strictEqual(request(req, ["text/*", "image/*"]), false);
+      assert.strictEqual(request([])(req), undefined);
+      assert.strictEqual(request(["image/*"])(req), undefined);
+      assert.strictEqual(request(["text/*", "image/*"])(req), undefined);
     });
   });
 
   describe("give no types", () => {
-    it("should return the mime type", () => {
+    it("should return undefined", () => {
       const req = createRequest("image/png");
-      assert.strictEqual(request(req), "image/png");
+      assert.strictEqual(request([])(req), undefined);
     });
   });
 
   describe("given one type", () => {
-    it("should return the type or false", () => {
-      const req = createRequest("image/png");
+    it("should return the matched type or undefined", () => {
+      const req = createRequest("application/json");
 
-      assert.strictEqual(request(req, ["png"]), "png");
-      assert.strictEqual(request(req, [".png"]), ".png");
-      assert.strictEqual(request(req, ["image/png"]), "image/png");
-      assert.strictEqual(request(req, ["image/*"]), "image/png");
-      assert.strictEqual(request(req, ["*/png"]), "image/png");
+      assert.strictEqual(request(["json"])(req), "application/json");
+      assert.strictEqual(
+        request(["application/json"])(req),
+        "application/json",
+      );
+      assert.strictEqual(request(["application/*"])(req), "application/*");
+      assert.strictEqual(request(["*/json"])(req), "*/json");
 
-      assert.strictEqual(request(req, ["jpeg"]), false);
-      assert.strictEqual(request(req, [".jpeg"]), false);
-      assert.strictEqual(request(req, ["image/jpeg"]), false);
-      assert.strictEqual(request(req, ["text/*"]), false);
-      assert.strictEqual(request(req, ["*/jpeg"]), false);
-
-      assert.strictEqual(request(req, ["bogus"]), false);
-      assert.strictEqual(request(req, ["something/bogus*"]), false);
+      assert.strictEqual(request(["image/jpeg"])(req), undefined);
+      assert.strictEqual(request(["text/*"])(req), undefined);
+      assert.strictEqual(request(["*/jpeg"])(req), undefined);
     });
   });
 
   describe("given multiple types", () => {
-    it("should return the first match or false", () => {
+    it("should return the first match or undefined", () => {
       const req = createRequest("image/png");
 
-      assert.strictEqual(request(req, ["png"]), "png");
-      assert.strictEqual(request(req, [".png"]), ".png");
-      assert.strictEqual(request(req, ["text/*", "image/*"]), "image/png");
-      assert.strictEqual(request(req, ["image/*", "text/*"]), "image/png");
-      assert.strictEqual(request(req, ["image/*", "image/png"]), "image/png");
-      assert.strictEqual(request(req, ["image/png", "image/*"]), "image/png");
+      assert.strictEqual(request(["text/*", "image/*"])(req), "image/*");
+      assert.strictEqual(request(["image/*", "text/*"])(req), "image/*");
+      assert.strictEqual(request(["image/*", "image/png"])(req), "image/*");
+      assert.strictEqual(request(["image/png", "image/*"])(req), "image/png");
 
-      assert.strictEqual(request(req, ["jpeg"]), false);
-      assert.strictEqual(request(req, [".jpeg"]), false);
-      assert.strictEqual(request(req, ["text/*", "application/*"]), false);
+      assert.strictEqual(request(["text/*", "application/*"])(req), undefined);
       assert.strictEqual(
-        request(req, ["text/html", "text/plain", "application/json"]),
-        false,
+        request(["text/html", "text/plain", "application/json"])(req),
+        undefined,
       );
     });
   });
@@ -98,48 +90,37 @@ describe("request(req, types)", () => {
     it("should match suffix types", () => {
       const req = createRequest("application/vnd+json");
 
-      assert.strictEqual(request(req, ["+json"]), "application/vnd+json");
+      assert.strictEqual(request(["+json"])(req), "*/*+json");
       assert.strictEqual(
-        request(req, ["application/vnd+json"]),
+        request(["application/vnd+json"])(req),
         "application/vnd+json",
       );
       assert.strictEqual(
-        request(req, ["application/*+json"]),
-        "application/vnd+json",
+        request(["application/*+json"])(req),
+        "application/*+json",
       );
-      assert.strictEqual(request(req, ["*/vnd+json"]), "application/vnd+json");
-      assert.strictEqual(request(req, ["application/json"]), false);
-      assert.strictEqual(request(req, ["text/*+json"]), false);
+      assert.strictEqual(request(["*/vnd+json"])(req), "*/vnd+json");
+      assert.strictEqual(request(["application/json"])(req), undefined);
+      assert.strictEqual(request(["text/*+json"])(req), undefined);
     });
   });
 
   describe('given "*/*"', () => {
     it("should match any content-type", () => {
-      assert.strictEqual(
-        request(createRequest("text/html"), ["*/*"]),
-        "text/html",
-      );
-      assert.strictEqual(
-        request(createRequest("text/xml"), ["*/*"]),
-        "text/xml",
-      );
-      assert.strictEqual(
-        request(createRequest("application/json"), ["*/*"]),
-        "application/json",
-      );
-      assert.strictEqual(
-        request(createRequest("application/vnd+json"), ["*/*"]),
-        "application/vnd+json",
-      );
+      const matches = request(["*/*"]);
+      assert.strictEqual(matches(createRequest("text/html")), "*/*");
+      assert.strictEqual(matches(createRequest("text/xml")), "*/*");
+      assert.strictEqual(matches(createRequest("application/json")), "*/*");
+      assert.strictEqual(matches(createRequest("application/vnd+json")), "*/*");
     });
 
     it("should not match invalid content-type", () => {
-      assert.strictEqual(request(createRequest("bogus"), ["*/*"]), false);
+      assert.strictEqual(request(["*/*"])(createRequest("bogus")), undefined);
     });
 
     it("should not match body-less request", () => {
       const req = { headers: { "content-type": "text/html" } };
-      assert.strictEqual(request(req, ["*/*"]), false);
+      assert.strictEqual(request(["*/*"])(req), undefined);
     });
   });
 
@@ -147,9 +128,18 @@ describe("request(req, types)", () => {
     it('should match "urlencoded"', () => {
       const req = createRequest("application/x-www-form-urlencoded");
 
-      assert.strictEqual(request(req, ["urlencoded"]), "urlencoded");
-      assert.strictEqual(request(req, ["json", "urlencoded"]), "urlencoded");
-      assert.strictEqual(request(req, ["urlencoded", "json"]), "urlencoded");
+      assert.strictEqual(
+        request(["urlencoded"])(req),
+        "application/x-www-form-urlencoded",
+      );
+      assert.strictEqual(
+        request(["json", "urlencoded"])(req),
+        "application/x-www-form-urlencoded",
+      );
+      assert.strictEqual(
+        request(["urlencoded", "json"])(req),
+        "application/x-www-form-urlencoded",
+      );
     });
   });
 
@@ -157,13 +147,13 @@ describe("request(req, types)", () => {
     it('should match "multipart/*"', () => {
       const req = createRequest("multipart/form-data");
 
-      assert.strictEqual(request(req, ["multipart/*"]), "multipart/form-data");
+      assert.strictEqual(request(["multipart/*"])(req), "multipart/*");
     });
 
     it('should match "multipart"', () => {
       const req = createRequest("multipart/form-data");
 
-      assert.strictEqual(request(req, ["multipart"]), "multipart");
+      assert.strictEqual(request(["multipart"])(req), "multipart/*");
     });
   });
 });
@@ -194,136 +184,102 @@ describe("hasBody(req)", () => {
   });
 });
 
-describe("is(mediaType, types)", () => {
+describe("is(types)", () => {
   it("should ignore params", () => {
-    assert.strictEqual(is("text/html; charset=utf-8", ["text/*"]), "text/html");
+    assert.strictEqual(is(["text/*"])("text/html; charset=utf-8"), "text/*");
   });
 
   it("should ignore casing", () => {
-    assert.strictEqual(is("text/HTML", ["text/*"]), "text/html");
+    assert.strictEqual(is(["text/*"])("text/HTML"), "text/*");
   });
 
-  it("should fail invalid type", () => {
-    assert.strictEqual(is("text/html**", ["text/*"]), false);
+  it("should match configured parameters", () => {
+    const matches = is(["text/html; charset=utf-8"]);
+    assert.strictEqual(matches("text/html; charset=utf-8"), "text/html");
+    assert.strictEqual(matches("text/html; charset=iso-8859-1"), undefined);
   });
 
   it("should not match invalid type", () => {
-    assert.strictEqual(is("text/html", ["text/html/"]), false);
-  });
-
-  describe("when no media type is given", () => {
-    it("should return false", () => {
-      assert.strictEqual(is("", ["application/json"]), false);
-      assert.strictEqual(is(null, ["image/*"]), false);
-      assert.strictEqual(is(undefined, ["text/*", "image/*"]), false);
-    });
-  });
-
-  describe("given no types", () => {
-    it("should return the mime type", () => {
-      assert.strictEqual(is("image/png"), "image/png");
-    });
+    assert.throws(() => is(["text/html/"]), /Invalid mime type/);
   });
 
   describe("given one type", () => {
-    it("should return the type or false", () => {
-      assert.strictEqual(is("image/png", ["png"]), "png");
-      assert.strictEqual(is("image/png", [".png"]), ".png");
-      assert.strictEqual(is("image/png", ["image/png"]), "image/png");
-      assert.strictEqual(is("image/png", ["image/*"]), "image/png");
-      assert.strictEqual(is("image/png", ["*/png"]), "image/png");
+    it("should return the type or undefined", () => {
+      assert.strictEqual(is(["image/png"])("image/png"), "image/png");
+      assert.strictEqual(is(["image/*"])("image/png"), "image/*");
+      assert.strictEqual(is(["*/png"])("image/png"), "*/png");
 
-      assert.strictEqual(is("image/png", ["jpeg"]), false);
-      assert.strictEqual(is("image/png", [".jpeg"]), false);
-      assert.strictEqual(is("image/png", ["image/jpeg"]), false);
-      assert.strictEqual(is("image/png", ["text/*"]), false);
-      assert.strictEqual(is("image/png", ["*/jpeg"]), false);
-
-      assert.strictEqual(is("image/png", ["bogus"]), false);
-      assert.strictEqual(is("image/png", ["something/bogus*"]), false);
+      assert.strictEqual(is(["image/jpeg"])("image/png"), undefined);
+      assert.strictEqual(is(["text/*"])("image/png"), undefined);
+      assert.strictEqual(is(["*/jpeg"])("image/png"), undefined);
     });
   });
 
   describe("given multiple types", () => {
-    it("should return the first match or false", () => {
-      assert.strictEqual(is("image/png", ["png"]), "png");
-      assert.strictEqual(is("image/png", [".png"]), ".png");
-      assert.strictEqual(is("image/png", ["text/*", "image/*"]), "image/png");
-      assert.strictEqual(is("image/png", ["image/*", "text/*"]), "image/png");
+    it("should return the first match or undefined", () => {
+      assert.strictEqual(is(["text/*", "image/*"])("image/png"), "image/*");
+      assert.strictEqual(is(["image/*", "text/*"])("image/png"), "image/*");
+      assert.strictEqual(is(["image/*", "image/png"])("image/png"), "image/*");
       assert.strictEqual(
-        is("image/png", ["image/*", "image/png"]),
-        "image/png",
-      );
-      assert.strictEqual(
-        is("image/png", ["image/png", "image/*"]),
+        is(["image/png", "image/*"])("image/png"),
         "image/png",
       );
 
-      assert.strictEqual(is("image/png", ["jpeg"]), false);
-      assert.strictEqual(is("image/png", [".jpeg"]), false);
-      assert.strictEqual(is("image/png", ["text/*", "application/*"]), false);
       assert.strictEqual(
-        is("image/png", ["text/html", "text/plain", "application/json"]),
-        false,
+        is(["text/*", "application/*"])("image/png"),
+        undefined,
+      );
+      assert.strictEqual(
+        is(["text/html", "text/plain", "application/json"])("image/png"),
+        undefined,
       );
     });
   });
 
   describe("given +suffix", () => {
     it("should match suffix types", () => {
+      assert.strictEqual(is(["+json"])("application/vnd+json"), "*/*+json");
       assert.strictEqual(
-        is("application/vnd+json", ["+json"]),
+        is(["application/vnd+json"])("application/vnd+json"),
         "application/vnd+json",
       );
       assert.strictEqual(
-        is("application/vnd+json", ["application/vnd+json"]),
-        "application/vnd+json",
+        is(["application/*+json"])("application/vnd+json"),
+        "application/*+json",
       );
       assert.strictEqual(
-        is("application/vnd+json", ["application/*+json"]),
-        "application/vnd+json",
+        is(["*/vnd+json"])("application/vnd+json"),
+        "*/vnd+json",
       );
       assert.strictEqual(
-        is("application/vnd+json", ["*/vnd+json"]),
-        "application/vnd+json",
+        is(["application/json"])("application/vnd+json"),
+        undefined,
       );
       assert.strictEqual(
-        is("application/vnd+json", ["application/json"]),
-        false,
+        is(["text/*+json"])("application/vnd+json"),
+        undefined,
       );
-      assert.strictEqual(is("application/vnd+json", ["text/*+json"]), false);
     });
   });
 
   describe('given "*/*"', () => {
     it("should match any media type", () => {
-      assert.strictEqual(is("text/html", ["*/*"]), "text/html");
-      assert.strictEqual(is("text/xml", ["*/*"]), "text/xml");
-      assert.strictEqual(is("application/json", ["*/*"]), "application/json");
-      assert.strictEqual(
-        is("application/vnd+json", ["*/*"]),
-        "application/vnd+json",
-      );
+      assert.strictEqual(is(["*/*"])("text/html"), "*/*");
+      assert.strictEqual(is(["*/*"])("text/xml"), "*/*");
+      assert.strictEqual(is(["*/*"])("application/json"), "*/*");
+      assert.strictEqual(is(["*/*"])("application/vnd+json"), "*/*");
     });
 
     it("should not match invalid media type", () => {
-      assert.strictEqual(is("bogus", ["*/*"]), false);
+      assert.strictEqual(is(["*/*"])("bogus"), undefined);
     });
   });
 
   describe("when media type is application/x-www-form-urlencoded", () => {
     it('should match "urlencoded"', () => {
       assert.strictEqual(
-        is("application/x-www-form-urlencoded", ["urlencoded"]),
-        "urlencoded",
-      );
-      assert.strictEqual(
-        is("application/x-www-form-urlencoded", ["json", "urlencoded"]),
-        "urlencoded",
-      );
-      assert.strictEqual(
-        is("application/x-www-form-urlencoded", ["urlencoded", "json"]),
-        "urlencoded",
+        is(["urlencoded"])("application/x-www-form-urlencoded"),
+        "application/x-www-form-urlencoded",
       );
     });
   });
@@ -331,49 +287,67 @@ describe("is(mediaType, types)", () => {
   describe("when media type is multipart/form-data", () => {
     it('should match "multipart/*"', () => {
       assert.strictEqual(
-        is("multipart/form-data", ["multipart/*"]),
-        "multipart/form-data",
+        is(["multipart/*"])("multipart/form-data"),
+        "multipart/*",
       );
     });
 
     it('should match "multipart"', () => {
-      assert.strictEqual(is("multipart/form-data", ["multipart"]), "multipart");
+      assert.strictEqual(
+        is(["multipart"])("multipart/form-data"),
+        "multipart/*",
+      );
     });
   });
 });
 
-describe("match(expected, actual)", () => {
+describe("match(expected)", () => {
   it("should perform exact matching", () => {
-    assert.strictEqual(match("text/html", "text/html"), true);
-    assert.strictEqual(match("text/html", "text/plain"), false);
-    assert.strictEqual(match("text/html", "text/xml"), false);
-    assert.strictEqual(match("text/html", "application/html"), false);
-    assert.strictEqual(match("text/html", "text/html+xml"), false);
+    const matches = match("text/html");
+    assert.strictEqual(matches("text/html"), true);
+    assert.strictEqual(matches("text/plain"), false);
+    assert.strictEqual(matches("text/xml"), false);
+    assert.strictEqual(matches("application/html"), false);
+    assert.strictEqual(matches("text/html+xml"), false);
   });
 
   it("should perform type wildcard matching", () => {
-    assert.strictEqual(match("*/html", "text/html"), true);
-    assert.strictEqual(match("*/html", "application/html"), true);
-    assert.strictEqual(match("*/html", "text/xml"), false);
-    assert.strictEqual(match("*/html", "text/html+xml"), false);
+    const matches = match("*/html");
+    assert.strictEqual(matches("text/html"), true);
+    assert.strictEqual(matches("application/html"), true);
+    assert.strictEqual(matches("text/xml"), false);
+    assert.strictEqual(matches("text/html+xml"), false);
   });
 
   it("should perform subtype wildcard matching", () => {
-    assert.strictEqual(match("text/*", "text/html"), true);
-    assert.strictEqual(match("text/*", "text/xml"), true);
-    assert.strictEqual(match("text/*", "text/html+xml"), true);
-    assert.strictEqual(match("text/*", "application/xml"), false);
+    const matches = match("text/*");
+    assert.strictEqual(matches("text/html"), true);
+    assert.strictEqual(matches("text/xml"), true);
+    assert.strictEqual(matches("text/html+xml"), true);
+    assert.strictEqual(matches("application/xml"), false);
   });
 
   it("should perform full wildcard matching", () => {
-    assert.strictEqual(match("*/*", "text/html"), true);
-    assert.strictEqual(match("*/*", "text/html+xml"), true);
-    assert.strictEqual(match("*/*+xml", "text/html+xml"), true);
+    const matches = match("*/*");
+    assert.strictEqual(matches("text/html"), true);
+    assert.strictEqual(matches("text/html+xml"), true);
   });
 
   it("should perform full wildcard matching with specific suffix", () => {
-    assert.strictEqual(match("*/*+xml", "text/html+xml"), true);
-    assert.strictEqual(match("*/*+xml", "text/html"), false);
+    const matches = match("*/*+xml");
+    assert.strictEqual(matches("text/html+xml"), true);
+    assert.strictEqual(matches("text/html"), false);
+  });
+
+  it("should reject invalid expected types", () => {
+    assert.throws(() => match("text"), /Invalid mime type/);
+    assert.throws(() => match("text\/html\/xml"), /Invalid mime type/);
+  });
+
+  it("should not match invalid actual types", () => {
+    const matches = match("text/*");
+    assert.strictEqual(matches("text"), false);
+    assert.strictEqual(matches("text/html/xml"), false);
   });
 });
 
@@ -395,8 +369,8 @@ describe("normalize(type)", () => {
     assert.strictEqual(normalize("image/*"), "image/*");
   });
 
-  it("should return empty string for unmapped extension", () => {
-    assert.strictEqual(normalize("unknown"), "");
+  it("should pass through unmapped extension", () => {
+    assert.strictEqual(normalize("unknown"), "unknown");
   });
 
   it('should expand special "urlencoded"', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,53 +1,56 @@
 import { describe, it, assert } from "vitest";
-import { is, request, hasBody, normalize, match } from "./index.js";
+import { TypeIs, hasBody, normalize, match } from "./index.js";
 
-describe("request(types)", () => {
+describe("TypeIs#request(req)", () => {
   it("should ignore params", () => {
     const req = createRequest("text/html; charset=utf-8");
-    assert.strictEqual(request(["text/*"])(req), "text/*");
+    assert.strictEqual(new TypeIs(["text/*"]).request(req), "text/*");
   });
 
   it("should ignore params LWS", () => {
     const req = createRequest("text/html ; charset=utf-8");
-    assert.strictEqual(request(["text/*"])(req), "text/*");
+    assert.strictEqual(new TypeIs(["text/*"]).request(req), "text/*");
   });
 
   it("should ignore casing", () => {
     const req = createRequest("text/HTML");
-    assert.strictEqual(request(["text/*"])(req), "text/*");
+    assert.strictEqual(new TypeIs(["text/*"]).request(req), "text/*");
   });
 
   it("should parse the content-type header", () => {
     const req = createRequest("text/html**");
-    assert.strictEqual(request(["text/*"])(req), "text/*");
+    assert.strictEqual(new TypeIs(["text/*"]).request(req), "text/*");
   });
 
   it("should reject invalid expected types", () => {
-    assert.throws(() => request(["text/html/"]), /Invalid mime type/);
+    assert.throws(() => new TypeIs(["text/html/"]), /Invalid mime type/);
   });
 
   describe("when no body is given", () => {
     it("should return undefined", () => {
       const req = { headers: {} };
 
-      assert.strictEqual(request([])(req), undefined);
-      assert.strictEqual(request(["image/*"])(req), undefined);
+      assert.strictEqual(new TypeIs([]).request(req), undefined);
+      assert.strictEqual(new TypeIs(["image/*"]).request(req), undefined);
     });
   });
 
   describe("when no content type is given", () => {
     it("should return undefined", () => {
       const req = createRequest();
-      assert.strictEqual(request([])(req), undefined);
-      assert.strictEqual(request(["image/*"])(req), undefined);
-      assert.strictEqual(request(["text/*", "image/*"])(req), undefined);
+      assert.strictEqual(new TypeIs([]).request(req), undefined);
+      assert.strictEqual(new TypeIs(["image/*"]).request(req), undefined);
+      assert.strictEqual(
+        new TypeIs(["text/*", "image/*"]).request(req),
+        undefined,
+      );
     });
   });
 
   describe("give no types", () => {
     it("should return undefined", () => {
       const req = createRequest("image/png");
-      assert.strictEqual(request([])(req), undefined);
+      assert.strictEqual(new TypeIs([]).request(req), undefined);
     });
   });
 
@@ -55,17 +58,20 @@ describe("request(types)", () => {
     it("should return the matched type or undefined", () => {
       const req = createRequest("application/json");
 
-      assert.strictEqual(request(["json"])(req), "application/json");
+      assert.strictEqual(new TypeIs(["json"]).request(req), "application/json");
       assert.strictEqual(
-        request(["application/json"])(req),
+        new TypeIs(["application/json"]).request(req),
         "application/json",
       );
-      assert.strictEqual(request(["application/*"])(req), "application/*");
-      assert.strictEqual(request(["*/json"])(req), "*/json");
+      assert.strictEqual(
+        new TypeIs(["application/*"]).request(req),
+        "application/*",
+      );
+      assert.strictEqual(new TypeIs(["*/json"]).request(req), "*/json");
 
-      assert.strictEqual(request(["image/jpeg"])(req), undefined);
-      assert.strictEqual(request(["text/*"])(req), undefined);
-      assert.strictEqual(request(["*/jpeg"])(req), undefined);
+      assert.strictEqual(new TypeIs(["image/jpeg"]).request(req), undefined);
+      assert.strictEqual(new TypeIs(["text/*"]).request(req), undefined);
+      assert.strictEqual(new TypeIs(["*/jpeg"]).request(req), undefined);
     });
   });
 
@@ -73,14 +79,31 @@ describe("request(types)", () => {
     it("should return the first match or undefined", () => {
       const req = createRequest("image/png");
 
-      assert.strictEqual(request(["text/*", "image/*"])(req), "image/*");
-      assert.strictEqual(request(["image/*", "text/*"])(req), "image/*");
-      assert.strictEqual(request(["image/*", "image/png"])(req), "image/*");
-      assert.strictEqual(request(["image/png", "image/*"])(req), "image/png");
-
-      assert.strictEqual(request(["text/*", "application/*"])(req), undefined);
       assert.strictEqual(
-        request(["text/html", "text/plain", "application/json"])(req),
+        new TypeIs(["text/*", "image/*"]).request(req),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/*", "text/*"]).request(req),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/*", "image/png"]).request(req),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/png", "image/*"]).request(req),
+        "image/png",
+      );
+
+      assert.strictEqual(
+        new TypeIs(["text/*", "application/*"]).request(req),
+        undefined,
+      );
+      assert.strictEqual(
+        new TypeIs(["text/html", "text/plain", "application/json"]).request(
+          req,
+        ),
         undefined,
       );
     });
@@ -90,37 +113,49 @@ describe("request(types)", () => {
     it("should match suffix types", () => {
       const req = createRequest("application/vnd+json");
 
-      assert.strictEqual(request(["+json"])(req), "*/*+json");
+      assert.strictEqual(new TypeIs(["+json"]).request(req), "*/*+json");
       assert.strictEqual(
-        request(["application/vnd+json"])(req),
+        new TypeIs(["application/vnd+json"]).request(req),
         "application/vnd+json",
       );
       assert.strictEqual(
-        request(["application/*+json"])(req),
+        new TypeIs(["application/*+json"]).request(req),
         "application/*+json",
       );
-      assert.strictEqual(request(["*/vnd+json"])(req), "*/vnd+json");
-      assert.strictEqual(request(["application/json"])(req), undefined);
-      assert.strictEqual(request(["text/*+json"])(req), undefined);
+      assert.strictEqual(new TypeIs(["*/vnd+json"]).request(req), "*/vnd+json");
+      assert.strictEqual(
+        new TypeIs(["application/json"]).request(req),
+        undefined,
+      );
+      assert.strictEqual(new TypeIs(["text/*+json"]).request(req), undefined);
     });
   });
 
   describe('given "*/*"', () => {
     it("should match any content-type", () => {
-      const matches = request(["*/*"]);
-      assert.strictEqual(matches(createRequest("text/html")), "*/*");
-      assert.strictEqual(matches(createRequest("text/xml")), "*/*");
-      assert.strictEqual(matches(createRequest("application/json")), "*/*");
-      assert.strictEqual(matches(createRequest("application/vnd+json")), "*/*");
+      const matches = new TypeIs(["*/*"]);
+      assert.strictEqual(matches.request(createRequest("text/html")), "*/*");
+      assert.strictEqual(matches.request(createRequest("text/xml")), "*/*");
+      assert.strictEqual(
+        matches.request(createRequest("application/json")),
+        "*/*",
+      );
+      assert.strictEqual(
+        matches.request(createRequest("application/vnd+json")),
+        "*/*",
+      );
     });
 
     it("should not match invalid content-type", () => {
-      assert.strictEqual(request(["*/*"])(createRequest("bogus")), undefined);
+      assert.strictEqual(
+        new TypeIs(["*/*"]).request(createRequest("bogus")),
+        undefined,
+      );
     });
 
     it("should not match body-less request", () => {
       const req = { headers: { "content-type": "text/html" } };
-      assert.strictEqual(request(["*/*"])(req), undefined);
+      assert.strictEqual(new TypeIs(["*/*"]).request(req), undefined);
     });
   });
 
@@ -129,15 +164,15 @@ describe("request(types)", () => {
       const req = createRequest("application/x-www-form-urlencoded");
 
       assert.strictEqual(
-        request(["urlencoded"])(req),
+        new TypeIs(["urlencoded"]).request(req),
         "application/x-www-form-urlencoded",
       );
       assert.strictEqual(
-        request(["json", "urlencoded"])(req),
+        new TypeIs(["json", "urlencoded"]).request(req),
         "application/x-www-form-urlencoded",
       );
       assert.strictEqual(
-        request(["urlencoded", "json"])(req),
+        new TypeIs(["urlencoded", "json"]).request(req),
         "application/x-www-form-urlencoded",
       );
     });
@@ -147,14 +182,68 @@ describe("request(types)", () => {
     it('should match "multipart/*"', () => {
       const req = createRequest("multipart/form-data");
 
-      assert.strictEqual(request(["multipart/*"])(req), "multipart/*");
+      assert.strictEqual(
+        new TypeIs(["multipart/*"]).request(req),
+        "multipart/*",
+      );
     });
 
     it('should match "multipart"', () => {
       const req = createRequest("multipart/form-data");
 
-      assert.strictEqual(request(["multipart"])(req), "multipart/*");
+      assert.strictEqual(new TypeIs(["multipart"]).request(req), "multipart/*");
     });
+  });
+});
+
+describe("TypeIs#contentType(contentType)", () => {
+  it("should return the first matching type", () => {
+    const matches = new TypeIs(["text/*", "application/*", "application/json"]);
+
+    assert.strictEqual(
+      matches.contentType({ type: "application/json", parameters: {} }),
+      "application/*",
+    );
+  });
+
+  it("should return undefined when no type matches", () => {
+    const matches = new TypeIs(["text/*"]);
+
+    assert.strictEqual(
+      matches.contentType({ type: "application/json", parameters: {} }),
+      undefined,
+    );
+  });
+
+  it("should match configured parameters", () => {
+    const matches = new TypeIs(["text/html; charset=utf-8"]);
+
+    assert.strictEqual(
+      matches.contentType({
+        type: "text/html",
+        parameters: { charset: "utf-8", boundary: "example" },
+      }),
+      "text/html",
+    );
+    assert.strictEqual(
+      matches.contentType({
+        type: "text/html",
+        parameters: { charset: "iso-8859-1" },
+      }),
+      undefined,
+    );
+  });
+
+  it("should fall through a parameter mismatch", () => {
+    const matches = new TypeIs(["text/html; charset=utf-8", "text/html"]);
+
+    assert.strictEqual(
+      matches.contentType({
+        type: "text/html",
+        parameters: { charset: "iso-8859-1" },
+      }),
+      "text/html",
+    );
   });
 });
 
@@ -184,28 +273,31 @@ describe("hasBody(req)", () => {
   });
 });
 
-describe("is(types)", () => {
+describe("TypeIs#is(value)", () => {
   it("should ignore params", () => {
-    assert.strictEqual(is(["text/*"])("text/html; charset=utf-8"), "text/*");
+    assert.strictEqual(
+      new TypeIs(["text/*"]).is("text/html; charset=utf-8"),
+      "text/*",
+    );
   });
 
   it("should ignore casing", () => {
-    assert.strictEqual(is(["text/*"])("text/HTML"), "text/*");
+    assert.strictEqual(new TypeIs(["text/*"]).is("text/HTML"), "text/*");
   });
 
   it("should match configured parameters", () => {
-    const matches = is(["text/html; charset=utf-8"]);
-    assert.strictEqual(matches("text/html; charset=utf-8"), "text/html");
-    assert.strictEqual(matches("text/html; charset=iso-8859-1"), undefined);
+    const matches = new TypeIs(["text/html; charset=utf-8"]);
+    assert.strictEqual(matches.is("text/html; charset=utf-8"), "text/html");
+    assert.strictEqual(matches.is("text/html; charset=iso-8859-1"), undefined);
   });
 
   it("should not match invalid type", () => {
-    assert.throws(() => is(["text/html/"]), /Invalid mime type/);
+    assert.throws(() => new TypeIs(["text/html/"]), /Invalid mime type/);
   });
 
   describe("with lookup option", () => {
     it("should match a string mapping", () => {
-      const matches = is(["yaml"], {
+      const matches = new TypeIs(["yaml"], {
         lookup: (value: string) => {
           switch (value) {
             case "yaml":
@@ -216,12 +308,12 @@ describe("is(types)", () => {
         },
       });
 
-      assert.strictEqual(matches("application/yaml"), "application/yaml");
-      assert.strictEqual(matches("text/yaml"), undefined);
+      assert.strictEqual(matches.is("application/yaml"), "application/yaml");
+      assert.strictEqual(matches.is("text/yaml"), undefined);
     });
 
     it("should match a string array mapping", () => {
-      const matches = is(["yaml"], {
+      const matches = new TypeIs(["yaml"], {
         lookup: (value: string) => {
           switch (value) {
             case "yaml":
@@ -232,39 +324,53 @@ describe("is(types)", () => {
         },
       });
 
-      assert.strictEqual(matches("application/yaml"), "application/yaml");
-      assert.strictEqual(matches("text/yaml"), "text/yaml");
+      assert.strictEqual(matches.is("application/yaml"), "application/yaml");
+      assert.strictEqual(matches.is("text/yaml"), "text/yaml");
     });
   });
 
   describe("given one type", () => {
     it("should return the type or undefined", () => {
-      assert.strictEqual(is(["image/png"])("image/png"), "image/png");
-      assert.strictEqual(is(["image/*"])("image/png"), "image/*");
-      assert.strictEqual(is(["*/png"])("image/png"), "*/png");
+      assert.strictEqual(
+        new TypeIs(["image/png"]).is("image/png"),
+        "image/png",
+      );
+      assert.strictEqual(new TypeIs(["image/*"]).is("image/png"), "image/*");
+      assert.strictEqual(new TypeIs(["*/png"]).is("image/png"), "*/png");
 
-      assert.strictEqual(is(["image/jpeg"])("image/png"), undefined);
-      assert.strictEqual(is(["text/*"])("image/png"), undefined);
-      assert.strictEqual(is(["*/jpeg"])("image/png"), undefined);
+      assert.strictEqual(new TypeIs(["image/jpeg"]).is("image/png"), undefined);
+      assert.strictEqual(new TypeIs(["text/*"]).is("image/png"), undefined);
+      assert.strictEqual(new TypeIs(["*/jpeg"]).is("image/png"), undefined);
     });
   });
 
   describe("given multiple types", () => {
     it("should return the first match or undefined", () => {
-      assert.strictEqual(is(["text/*", "image/*"])("image/png"), "image/*");
-      assert.strictEqual(is(["image/*", "text/*"])("image/png"), "image/*");
-      assert.strictEqual(is(["image/*", "image/png"])("image/png"), "image/*");
       assert.strictEqual(
-        is(["image/png", "image/*"])("image/png"),
+        new TypeIs(["text/*", "image/*"]).is("image/png"),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/*", "text/*"]).is("image/png"),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/*", "image/png"]).is("image/png"),
+        "image/*",
+      );
+      assert.strictEqual(
+        new TypeIs(["image/png", "image/*"]).is("image/png"),
         "image/png",
       );
 
       assert.strictEqual(
-        is(["text/*", "application/*"])("image/png"),
+        new TypeIs(["text/*", "application/*"]).is("image/png"),
         undefined,
       );
       assert.strictEqual(
-        is(["text/html", "text/plain", "application/json"])("image/png"),
+        new TypeIs(["text/html", "text/plain", "application/json"]).is(
+          "image/png",
+        ),
         undefined,
       );
     });
@@ -272,25 +378,28 @@ describe("is(types)", () => {
 
   describe("given +suffix", () => {
     it("should match suffix types", () => {
-      assert.strictEqual(is(["+json"])("application/vnd+json"), "*/*+json");
       assert.strictEqual(
-        is(["application/vnd+json"])("application/vnd+json"),
+        new TypeIs(["+json"]).is("application/vnd+json"),
+        "*/*+json",
+      );
+      assert.strictEqual(
+        new TypeIs(["application/vnd+json"]).is("application/vnd+json"),
         "application/vnd+json",
       );
       assert.strictEqual(
-        is(["application/*+json"])("application/vnd+json"),
+        new TypeIs(["application/*+json"]).is("application/vnd+json"),
         "application/*+json",
       );
       assert.strictEqual(
-        is(["*/vnd+json"])("application/vnd+json"),
+        new TypeIs(["*/vnd+json"]).is("application/vnd+json"),
         "*/vnd+json",
       );
       assert.strictEqual(
-        is(["application/json"])("application/vnd+json"),
+        new TypeIs(["application/json"]).is("application/vnd+json"),
         undefined,
       );
       assert.strictEqual(
-        is(["text/*+json"])("application/vnd+json"),
+        new TypeIs(["text/*+json"]).is("application/vnd+json"),
         undefined,
       );
     });
@@ -298,21 +407,21 @@ describe("is(types)", () => {
 
   describe('given "*/*"', () => {
     it("should match any media type", () => {
-      assert.strictEqual(is(["*/*"])("text/html"), "*/*");
-      assert.strictEqual(is(["*/*"])("text/xml"), "*/*");
-      assert.strictEqual(is(["*/*"])("application/json"), "*/*");
-      assert.strictEqual(is(["*/*"])("application/vnd+json"), "*/*");
+      assert.strictEqual(new TypeIs(["*/*"]).is("text/html"), "*/*");
+      assert.strictEqual(new TypeIs(["*/*"]).is("text/xml"), "*/*");
+      assert.strictEqual(new TypeIs(["*/*"]).is("application/json"), "*/*");
+      assert.strictEqual(new TypeIs(["*/*"]).is("application/vnd+json"), "*/*");
     });
 
     it("should not match invalid media type", () => {
-      assert.strictEqual(is(["*/*"])("bogus"), undefined);
+      assert.strictEqual(new TypeIs(["*/*"]).is("bogus"), undefined);
     });
   });
 
   describe("when media type is application/x-www-form-urlencoded", () => {
     it('should match "urlencoded"', () => {
       assert.strictEqual(
-        is(["urlencoded"])("application/x-www-form-urlencoded"),
+        new TypeIs(["urlencoded"]).is("application/x-www-form-urlencoded"),
         "application/x-www-form-urlencoded",
       );
     });
@@ -321,14 +430,14 @@ describe("is(types)", () => {
   describe("when media type is multipart/form-data", () => {
     it('should match "multipart/*"', () => {
       assert.strictEqual(
-        is(["multipart/*"])("multipart/form-data"),
+        new TypeIs(["multipart/*"]).is("multipart/form-data"),
         "multipart/*",
       );
     });
 
     it('should match "multipart"', () => {
       assert.strictEqual(
-        is(["multipart"])("multipart/form-data"),
+        new TypeIs(["multipart"]).is("multipart/form-data"),
         "multipart/*",
       );
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -203,10 +203,17 @@ describe("is(types)", () => {
     assert.throws(() => is(["text/html/"]), /Invalid mime type/);
   });
 
-  describe("with extensions option", () => {
+  describe("with lookup option", () => {
     it("should match a string mapping", () => {
       const matches = is(["yaml"], {
-        extensions: { yaml: "application/yaml" },
+        lookup: (value: string) => {
+          switch (value) {
+            case "yaml":
+              return "application/yaml";
+            default:
+              return undefined;
+          }
+        },
       });
 
       assert.strictEqual(matches("application/yaml"), "application/yaml");
@@ -215,7 +222,14 @@ describe("is(types)", () => {
 
     it("should match a string array mapping", () => {
       const matches = is(["yaml"], {
-        extensions: { yaml: ["application/yaml", "text/yaml"] },
+        lookup: (value: string) => {
+          switch (value) {
+            case "yaml":
+              return ["application/yaml", "text/yaml"];
+            default:
+              return undefined;
+          }
+        },
       });
 
       assert.strictEqual(matches("application/yaml"), "application/yaml");

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -203,6 +203,26 @@ describe("is(types)", () => {
     assert.throws(() => is(["text/html/"]), /Invalid mime type/);
   });
 
+  describe("with extensions option", () => {
+    it("should match a string mapping", () => {
+      const matches = is(["yaml"], {
+        extensions: { yaml: "application/yaml" },
+      });
+
+      assert.strictEqual(matches("application/yaml"), "application/yaml");
+      assert.strictEqual(matches("text/yaml"), undefined);
+    });
+
+    it("should match a string array mapping", () => {
+      const matches = is(["yaml"], {
+        extensions: { yaml: ["application/yaml", "text/yaml"] },
+      });
+
+      assert.strictEqual(matches("application/yaml"), "application/yaml");
+      assert.strictEqual(matches("text/yaml"), "text/yaml");
+    });
+  });
+
   describe("given one type", () => {
     it("should return the type or undefined", () => {
       assert.strictEqual(is(["image/png"])("image/png"), "image/png");

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,33 +5,13 @@
  * MIT Licensed
  */
 
-import { parse } from "content-type";
+import { parse, ContentType } from "content-type";
 
 /**
  * Node.js HTTP request shape.
  */
 export interface RequestLike {
   headers: Record<string, string | string[] | undefined>;
-}
-
-/**
- * Check if the incoming request contains the "Content-Type" header field, and
- * it contains any of the given mime `type`s. If there is no request body or
- * content type, `false` is returned. Otherwise, it returns the first `type`
- * that matches.
- */
-export function request(
-  types: string[],
-): (req: RequestLike) => string | undefined {
-  const isType = is(types);
-
-  return (req: RequestLike): string | undefined => {
-    if (!hasBody(req)) return;
-    const header = req.headers["content-type"];
-    if (!header) return;
-    const value = Array.isArray(header) ? header[0] : header;
-    return isType(value);
-  };
 }
 
 /**
@@ -119,48 +99,70 @@ interface Pattern {
   key: string;
   match: (value: string) => boolean;
   parameters: Record<string, string>;
+  hasParameters: boolean;
 }
 
-/**
- * Compile a list of expected mime types into a reusable matcher.
- */
-export function is(
-  types: string[],
-  options?: NormalizeOptions,
-): (value: string) => string | undefined {
-  let hasParameters = false;
-  const patterns: Pattern[] = [];
+export class TypeIs {
+  private readonly hasParameters: boolean = false;
+  private readonly patterns: Pattern[] = [];
 
-  for (const t of types) {
-    const contentType = parse(t);
-    hasParameters ||= Object.keys(contentType.parameters).length > 0;
-    const type = normalize(contentType.type, options);
+  /**
+   * Compile a list of expected mime types into a reusable matcher.
+   */
+  constructor(types: readonly string[], options?: NormalizeOptions) {
+    for (const t of types) {
+      const contentType = parse(t);
+      const hasParameters = Object.keys(contentType.parameters).length > 0;
+      const type = normalize(contentType.type, options);
 
-    if (Array.isArray(type)) {
-      for (const t of type) {
-        patterns.push({
-          key: t,
-          match: match(t),
+      this.hasParameters ||= hasParameters;
+
+      if (Array.isArray(type)) {
+        for (const t of type) {
+          this.patterns.push({
+            key: t,
+            match: match(t),
+            parameters: contentType.parameters,
+            hasParameters,
+          });
+        }
+      } else {
+        this.patterns.push({
+          key: type,
+          match: match(type),
           parameters: contentType.parameters,
+          hasParameters,
         });
       }
-    } else {
-      patterns.push({
-        key: type,
-        match: match(type),
-        parameters: contentType.parameters,
-      });
     }
   }
 
-  return function (value: string): string | undefined {
-    const contentType = parse(value, { parameters: hasParameters });
+  /**
+   * Check whether a content type matches one of the configured types.
+   */
+  is(value: string): string | undefined {
+    const contentType = parse(value, { parameters: this.hasParameters });
+    return this.contentType(contentType);
+  }
 
-    for (let i = 0; i < patterns.length; i++) {
-      const pattern = patterns[i];
+  /**
+   * Check whether a request body matches one of the configured types.
+   */
+  request(req: RequestLike): string | undefined {
+    if (!hasBody(req)) return;
+    const header = req.headers["content-type"];
+    if (!header) return;
+    const value = Array.isArray(header) ? header[0] : header;
+    return this.is(value);
+  }
+
+  contentType(
+    contentType: Pick<ContentType, "type" | "parameters">,
+  ): string | undefined {
+    for (const pattern of this.patterns) {
       if (pattern.match(contentType.type)) {
         const parametersMatch =
-          !hasParameters ||
+          !pattern.hasParameters ||
           Object.keys(pattern.parameters).every(
             (key) => pattern.parameters[key] === contentType.parameters[key],
           );
@@ -168,15 +170,5 @@ export function is(
         if (parametersMatch) return pattern.key;
       }
     }
-
-    return undefined;
-  };
-}
-
-export class TypeIs {
-  constructor(types: string[], options?: NormalizeOptions) {
-    this.matcher = is(types, options);
   }
-
-  private matcher: (value: string) => string | undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,6 @@
  */
 
 import { parse } from "content-type";
-import { lookup } from "mime-types";
-import { test } from "media-typer";
 
 /**
  * Node.js HTTP request shape.
@@ -22,11 +20,18 @@ export interface RequestLike {
  * content type, `false` is returned. Otherwise, it returns the first `type`
  * that matches.
  */
-export function request(req: RequestLike, types?: string[]): string | false {
-  if (!hasBody(req)) return false;
-  const header = req.headers["content-type"];
-  if (!header) return false;
-  return is(Array.isArray(header) ? header[0] : header, types);
+export function request(
+  types: string[],
+): (req: RequestLike) => string | undefined {
+  const isType = is(types);
+
+  return (req: RequestLike): string | undefined => {
+    if (!hasBody(req)) return;
+    const header = req.headers["content-type"];
+    if (!header) return;
+    const value = Array.isArray(header) ? header[0] : header;
+    return isType(value);
+  };
 }
 
 /**
@@ -40,82 +45,126 @@ export function hasBody(req: RequestLike): boolean {
   );
 }
 
+export const DEFAULT_EXTENSIONS: Record<string, string | string[]> =
+  Object.freeze({
+    json: "application/json",
+    urlencoded: "application/x-www-form-urlencoded",
+    multipart: "multipart/*",
+  });
+
+export interface NormalizeOptions {
+  extensions?: Record<string, string | string[]>;
+}
+
+export function normalize(
+  value: string,
+  options?: NormalizeOptions,
+): string | string[] {
+  if (value.includes("/")) return value;
+  if (value.startsWith("+")) return `*/*${value}`;
+  const extensions = options?.extensions ?? DEFAULT_EXTENSIONS;
+  return Object.prototype.hasOwnProperty.call(extensions, value)
+    ? extensions[value]
+    : value;
+}
+
 /**
- * Compare a `value` content-type with `types`. Each `type` can be an extension
- * like `html`, a special shortcut like `multipart` or `urlencoded`, or a mime
- * type.
- *
- * If no types match, `false` is returned. Otherwise, the first `type` that
- * matches is returned.
+ * Compile an expected mime type into a reusable matcher.
+ */
+export function match(expected: string): (actual: string) => boolean {
+  const expectedSlash = expected.indexOf("/");
+
+  if (expectedSlash === -1 || expected.indexOf("/", expectedSlash + 1) !== -1) {
+    throw new TypeError(`Invalid mime type: ${expected}`);
+  }
+
+  const type = expected.slice(0, expectedSlash);
+  let subtype = expected.slice(expectedSlash + 1);
+  let suffix = "";
+
+  if (subtype.startsWith("*+")) {
+    suffix = subtype.slice(1);
+    subtype = "*";
+  }
+
+  if (type !== "*" && subtype !== "*") {
+    return (actual: string): boolean => actual === expected;
+  }
+
+  return function (actual: string): boolean {
+    const actualSlash = actual.indexOf("/");
+
+    if (actualSlash === -1 || actual.indexOf("/", actualSlash + 1) !== -1) {
+      return false;
+    }
+
+    if (subtype === "*") {
+      if (!actual.endsWith(suffix)) return false;
+      if (type === "*") return true;
+      return expectedSlash === actualSlash && actual.startsWith(type);
+    }
+
+    return (
+      actualSlash === actual.length - subtype.length - 1 &&
+      actual.endsWith(subtype)
+    );
+  };
+}
+
+interface Pattern {
+  key: string;
+  match: (value: string) => boolean;
+  parameters: Record<string, string>;
+}
+
+/**
+ * Compile a list of expected mime types into a reusable matcher.
  */
 export function is(
-  value: string | undefined | null,
-  types?: string[],
-): string | false {
-  const val = normalizeType(value);
-  if (!val) return false;
-  if (!types || types.length === 0) return val;
+  types: string[],
+  options?: NormalizeOptions,
+): (value: string) => string | undefined {
+  let hasParameters = false;
+  const patterns: Pattern[] = [];
 
-  for (const type of types) {
-    const normalized = normalize(type);
-    if (match(normalized, val)) {
-      return type[0] === "+" || type.indexOf("*") !== -1 ? val : type;
+  for (const t of types) {
+    const contentType = parse(t);
+    hasParameters ||= Object.keys(contentType.parameters).length > 0;
+    const type = normalize(contentType.type, options);
+
+    if (Array.isArray(type)) {
+      for (const t of type) {
+        patterns.push({
+          key: t,
+          match: match(t),
+          parameters: contentType.parameters,
+        });
+      }
+    } else {
+      patterns.push({
+        key: type,
+        match: match(type),
+        parameters: contentType.parameters,
+      });
     }
   }
 
-  return false;
-}
+  return function (value: string): string | undefined {
+    const contentType = parse(value, { parameters: hasParameters });
 
-/**
- * Normalize a mime type. If it's a shorthand, expand it to a valid mime type.
- */
-export function normalize(type: string): string {
-  switch (type) {
-    case "urlencoded":
-      return "application/x-www-form-urlencoded";
-    case "multipart":
-      return "multipart/*";
-  }
+    for (let i = 0; i < patterns.length; i++) {
+      const pattern = patterns[i];
+      if (pattern.match(contentType.type)) {
+        const parametersMatch =
+          !hasParameters ||
+          Object.keys(pattern.parameters).every(
+            (key) => pattern.parameters[key] === contentType.parameters[key],
+          );
 
-  if (type.startsWith("+")) return `*/*${type}`;
-  if (type.includes("/")) return type;
-  return lookup(type) || "";
-}
+        if (parametersMatch) return pattern.key;
+      }
+    }
 
-/**
- * Check if `expected` mime type matches `actual` mime type with wildcard and
- * +suffix support.
- */
-export function match(expected: string, actual: string): boolean {
-  const actualParts = actual.split("/");
-  const expectedParts = expected.split("/");
-
-  if (actualParts.length !== 2 || expectedParts.length !== 2) return false;
-
-  if (expectedParts[0] !== "*" && expectedParts[0] !== actualParts[0]) {
-    return false;
-  }
-
-  if (expectedParts[1].slice(0, 2) === "*+") {
-    return (
-      expectedParts[1].length <= actualParts[1].length + 1 &&
-      expectedParts[1].slice(1) ===
-        actualParts[1].slice(1 - expectedParts[1].length)
-    );
-  }
-
-  if (expectedParts[1] !== "*" && expectedParts[1] !== actualParts[1]) {
-    return false;
-  }
-
-  return true;
-}
-
-/**
- * Normalize a type and remove parameters.
- */
-function normalizeType(value: string | undefined | null): string | null {
-  if (!value) return null;
-  const { type } = parse(value, { parameters: false });
-  return test(type) ? type : null;
+    return undefined;
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,15 +45,21 @@ export function hasBody(req: RequestLike): boolean {
   );
 }
 
-export const DEFAULT_EXTENSIONS: Record<string, string | string[]> =
-  Object.freeze({
-    json: "application/json",
-    urlencoded: "application/x-www-form-urlencoded",
-    multipart: "multipart/*",
-  });
+export function DEFAULT_LOOKUP(value: string): string | string[] | undefined {
+  switch (value) {
+    case "urlencoded":
+      return "application/x-www-form-urlencoded";
+    case "multipart":
+      return "multipart/*";
+    case "json":
+      return "application/json";
+    default:
+      return undefined;
+  }
+}
 
 export interface NormalizeOptions {
-  extensions?: Record<string, string | string[]>;
+  lookup?: (value: string) => string | string[] | undefined;
 }
 
 export function normalize(
@@ -62,10 +68,8 @@ export function normalize(
 ): string | string[] {
   if (value.includes("/")) return value;
   if (value.startsWith("+")) return `*/*${value}`;
-  const extensions = options?.extensions ?? DEFAULT_EXTENSIONS;
-  return Object.prototype.hasOwnProperty.call(extensions, value)
-    ? extensions[value]
-    : value;
+  const lookup = options?.lookup ?? DEFAULT_LOOKUP;
+  return lookup(value) ?? value;
 }
 
 /**
@@ -167,4 +171,12 @@ export function is(
 
     return undefined;
   };
+}
+
+export class TypeIs {
+  constructor(types: string[], options?: NormalizeOptions) {
+    this.matcher = is(types, options);
+  }
+
+  private matcher: (value: string) => string | undefined;
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/**/*.bench.ts"]
 }


### PR DESCRIPTION
Refactors the API to be a cached/preprocessed function closure instead of parsing the matching pattern every time. Additionally solves https://github.com/jshttp/type-is/issues/14 by parsing parameters and matching them when provided.

It also changes the returned type to always be the matched one, instead of returning the matched except when it contained a wildcard.

Drops usage of `mime-types` from the library so it can be more easily used in a browser (the dependency is huge): https://github.com/jshttp/type-is/issues/45. However, I kept an option for `extensions` so it's possible for `mime-types` to still be passed into the library upstream (e.g. in express) without largely breaking expectations if wanted.